### PR TITLE
Feature/users signout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,3 @@ out/
 ### VS Code ###
 .vscode/
 
-### Spring Boot Configuration ###
-src/main/resources/application.properties

--- a/build.gradle
+++ b/build.gradle
@@ -28,10 +28,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     // JWT
-    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
-    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
-    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     // Apache Commons Lang
     implementation 'org.apache.commons:commons-lang3:3.14.0'
     // Bouncy Castle 암호화 라이브러리

--- a/src/main/java/com/zb/meeteat/config/RedisConfig.java
+++ b/src/main/java/com/zb/meeteat/config/RedisConfig.java
@@ -1,0 +1,26 @@
+package com.zb.meeteat.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory();
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        return template;
+    }
+}

--- a/src/main/java/com/zb/meeteat/domain/user/controller/AuthController.java
+++ b/src/main/java/com/zb/meeteat/domain/user/controller/AuthController.java
@@ -4,6 +4,7 @@ import com.zb.meeteat.domain.user.dto.AuthCodeResponseDto;
 import com.zb.meeteat.domain.user.dto.SigninRequestDto;
 import com.zb.meeteat.domain.user.dto.SignupRequestDto;
 import com.zb.meeteat.domain.user.service.AuthService;
+import com.zb.meeteat.domain.user.service.SocialAuthService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,6 +20,7 @@ import java.util.Map;
 public class AuthController {
 
     private final AuthService authService;
+    private final SocialAuthService socialAuthService;
 
     // 회원가입
     @PostMapping("/signup")
@@ -33,6 +35,7 @@ public class AuthController {
         return ResponseEntity.ok(authService.signin(requestDto));
     }
 
+    // 소셜 로그인
     @PostMapping("/signin/{provider}")
     public ResponseEntity<AuthCodeResponseDto> socialSignin(
             @PathVariable String provider,
@@ -46,8 +49,15 @@ public class AuthController {
             throw new IllegalArgumentException("인가 코드가 제공되지 않았습니다.");
         }
 
-        AuthCodeResponseDto response = authService.socialSignin(provider, authCode);
+        AuthCodeResponseDto response = socialAuthService.socialSignin(provider, authCode);
         return ResponseEntity.ok(response);
+    }
+
+    // 로그 아웃
+    @PostMapping("/signout")
+    public ResponseEntity<Void> signout(@RequestHeader("Authorization") String token) {
+        authService.signout(token);
+        return ResponseEntity.ok().build();
     }
 
 

--- a/src/main/java/com/zb/meeteat/domain/user/entity/User.java
+++ b/src/main/java/com/zb/meeteat/domain/user/entity/User.java
@@ -14,7 +14,7 @@ import java.util.UUID;
 @AllArgsConstructor
 @Entity
 @Builder
-@Table(name = "users", uniqueConstraints = {
+@Table(name = "user", uniqueConstraints = {
         @UniqueConstraint(columnNames = "email"),
         @UniqueConstraint(columnNames = "nickname")
 })

--- a/src/main/java/com/zb/meeteat/domain/user/service/AuthService.java
+++ b/src/main/java/com/zb/meeteat/domain/user/service/AuthService.java
@@ -9,18 +9,16 @@ import com.zb.meeteat.domain.user.entity.User;
 import com.zb.meeteat.domain.user.repository.UserRepository;
 import com.zb.meeteat.exception.CustomException;
 import com.zb.meeteat.exception.ErrorCode;
-import com.zb.meeteat.external.kakao.KakaoAuthClient;
-import com.zb.meeteat.external.kakao.KakaoTokenResponse;
-import com.zb.meeteat.external.kakao.KakaoUserResponse;
-import com.zb.meeteat.external.naver.NaverAuthClient;
-import com.zb.meeteat.external.naver.NaverTokenResponse;
-import com.zb.meeteat.external.naver.NaverUserResponse;
 import com.zb.meeteat.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -30,8 +28,6 @@ public class AuthService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
-    private final KakaoAuthClient kakaoAuthClient;
-    private final NaverAuthClient naverAuthClient;
 
     @Transactional
     public User signup(SignupRequestDto requestDto) {
@@ -85,104 +81,16 @@ public class AuthService {
     }
 
     @Transactional
-    public AuthCodeResponseDto socialSignin(String provider, String authCode) {
-        if ("kakao".equalsIgnoreCase(provider)) {
-            return processKakaoSignin(authCode);
-        } else if ("naver".equalsIgnoreCase(provider)) {
-            return processNaverSignin(authCode);
-        } else {
-            throw new IllegalArgumentException("지원하지 않는 소셜 로그인입니다.");
-        }
-    }
+    public void signout(String token) {
+        String jwt = token.replace("Bearer ", "");
 
-
-    public AuthCodeResponseDto processKakaoSignin(String authCode) {
-
-        try {
-            log.info("받은 authCode: {}", authCode);
-
-            // 카카오에서 토큰 가져오기
-            KakaoTokenResponse tokenResponse = kakaoAuthClient.getToken(authCode);
-            if (tokenResponse == null || tokenResponse.getAccessToken() == null) {
-                throw new IllegalArgumentException("카카오 액세스 토큰을 가져올 수 없습니다.");
-            }
-            log.info("받은 카카오 액세스 토큰: {}", tokenResponse.getAccessToken());
-
-            // 토큰을 이용해 사용자 정보 가져오기
-            KakaoUserResponse userResponse = kakaoAuthClient.getUserInfo(tokenResponse.getAccessToken());
-            if (userResponse == null || userResponse.getKakaoAccount() == null) {
-                throw new IllegalArgumentException("카카오 사용자 정보를 가져올 수 없습니다.");
-            }
-            log.info("받은 카카오 사용자 정보: {}", userResponse);
-
-            // 이메일 기준으로 사용자 확인 (기존 회원 목록에 없으면 새로 생성)
-            String email = userResponse.getKakaoAccount().getEmail();
-            if (email == null) {
-                throw new IllegalArgumentException("카카오 사용자 이메일 정보가 없습니다.");
-            }
-
-            User user = userRepository.findByEmail(email)
-                    .orElseGet(() -> {
-                        log.info("신규 카카오 사용자 저장: {}", email);
-                        return userRepository.save(User.ofKakao(userResponse));
-                    });
-
-
-            // JWT 발급
-            String jwtToken = jwtUtil.generateToken(user);
-            log.info("JWT 토큰 발급: {}", jwtToken);
-
-            // 응답 DTO 반환
-            return new AuthCodeResponseDto(jwtToken, user.isProfileIncomplete());
-
-        } catch (Exception e) {
-            log.error("카카오 로그인 중 오류 발생: {}", e.getMessage(), e);
-            throw new RuntimeException("카카오 로그인 중 오류 발생: " + e.getMessage());
-        }
-    }
-
-    private AuthCodeResponseDto processNaverSignin(String authCode) {
-        try {
-            log.info("받은 네이버 authCode: {}", authCode);
-
-            // 네이버에서 토큰 가져오기
-            NaverTokenResponse tokenResponse = naverAuthClient.getToken(authCode);
-            if (tokenResponse == null || tokenResponse.getAccessToken() == null) {
-                throw new IllegalArgumentException("네이버 액세스 토큰을 가져올 수 없습니다.");
-            }
-            log.info("받은 네이버 액세스 토큰: {}", tokenResponse.getAccessToken());
-
-            // 토큰을 이용해 사용자 정보 가져오기
-            NaverUserResponse userResponse = naverAuthClient.getUserInfo(tokenResponse.getAccessToken());
-            if (userResponse == null || userResponse.getResponse() == null) {
-                throw new IllegalArgumentException("네이버 사용자 정보를 가져올 수 없습니다.");
-            }
-            log.info("받은 네이버 사용자 정보: {}", userResponse);
-
-            // 이메일 기준으로 사용자 확인 (기존 회원 목록에 없으면 새로 생성)
-            String email = userResponse.getResponse().getEmail();
-            if (email == null) {
-                throw new IllegalArgumentException("네이버 사용자 이메일 정보가 없습니다.");
-            }
-
-            User user = userRepository.findByEmail(email)
-                    .orElseGet(() -> {
-                        log.info("신규 네이버 사용자 저장: {}", email);
-                        return userRepository.save(User.ofNaver(userResponse));
-                    });
-
-            // JWT 발급
-            String jwtToken = jwtUtil.generateToken(user);
-            log.info("JWT 토큰 발급: {}", jwtToken);
-
-            // 응답 DTO 반환
-            return new AuthCodeResponseDto(jwtToken, user.isProfileIncomplete());
-        } catch (Exception e) {
-            log.error("네이버 로그인 중 오류 발생: {}", e.getMessage(), e);
-            throw new RuntimeException("네이버 로그인 중 오류 발생: " + e.getMessage());
+        if (!jwtUtil.validateToken(jwt)) {
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
         }
 
+        jwtUtil.blacklistToken(jwt);
     }
+
 
 }
 

--- a/src/main/java/com/zb/meeteat/domain/user/service/SocialAuthService.java
+++ b/src/main/java/com/zb/meeteat/domain/user/service/SocialAuthService.java
@@ -1,0 +1,127 @@
+package com.zb.meeteat.domain.user.service;
+
+import com.zb.meeteat.domain.user.dto.AuthCodeResponseDto;
+import com.zb.meeteat.domain.user.entity.User;
+import com.zb.meeteat.domain.user.repository.UserRepository;
+import com.zb.meeteat.external.kakao.KakaoAuthClient;
+import com.zb.meeteat.external.kakao.KakaoTokenResponse;
+import com.zb.meeteat.external.kakao.KakaoUserResponse;
+import com.zb.meeteat.external.naver.NaverAuthClient;
+import com.zb.meeteat.external.naver.NaverTokenResponse;
+import com.zb.meeteat.external.naver.NaverUserResponse;
+import com.zb.meeteat.jwt.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class SocialAuthService {
+
+    private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+    private final KakaoAuthClient kakaoAuthClient;
+    private final NaverAuthClient naverAuthClient;
+
+    @Transactional
+    public AuthCodeResponseDto socialSignin(String provider, String authCode) {
+        if ("kakao".equalsIgnoreCase(provider)) {
+            return processKakaoSignin(authCode);
+        } else if ("naver".equalsIgnoreCase(provider)) {
+            return processNaverSignin(authCode);
+        } else {
+            throw new IllegalArgumentException("지원하지 않는 소셜 로그인입니다.");
+        }
+    }
+
+
+    public AuthCodeResponseDto processKakaoSignin(String authCode) {
+
+        try {
+            log.info("받은 authCode: {}", authCode);
+
+            // 카카오에서 토큰 가져오기
+            KakaoTokenResponse tokenResponse = kakaoAuthClient.getToken(authCode);
+            if (tokenResponse == null || tokenResponse.getAccessToken() == null) {
+                throw new IllegalArgumentException("카카오 액세스 토큰을 가져올 수 없습니다.");
+            }
+            log.info("받은 카카오 액세스 토큰: {}", tokenResponse.getAccessToken());
+
+            // 토큰을 이용해 사용자 정보 가져오기
+            KakaoUserResponse userResponse = kakaoAuthClient.getUserInfo(tokenResponse.getAccessToken());
+            if (userResponse == null || userResponse.getKakaoAccount() == null) {
+                throw new IllegalArgumentException("카카오 사용자 정보를 가져올 수 없습니다.");
+            }
+            log.info("받은 카카오 사용자 정보: {}", userResponse);
+
+            // 이메일 기준으로 사용자 확인 (기존 회원 목록에 없으면 새로 생성)
+            String email = userResponse.getKakaoAccount().getEmail();
+            if (email == null) {
+                throw new IllegalArgumentException("카카오 사용자 이메일 정보가 없습니다.");
+            }
+
+            User user = userRepository.findByEmail(email)
+                    .orElseGet(() -> {
+                        log.info("신규 카카오 사용자 저장: {}", email);
+                        return userRepository.save(User.ofKakao(userResponse));
+                    });
+
+
+            // JWT 발급
+            String jwtToken = jwtUtil.generateToken(user);
+            log.info("JWT 토큰 발급: {}", jwtToken);
+
+            // 응답 DTO 반환
+            return new AuthCodeResponseDto(jwtToken, user.isProfileIncomplete());
+
+        } catch (Exception e) {
+            log.error("카카오 로그인 중 오류 발생: {}", e.getMessage(), e);
+            throw new RuntimeException("카카오 로그인 중 오류 발생: " + e.getMessage());
+        }
+    }
+
+    private AuthCodeResponseDto processNaverSignin(String authCode) {
+        try {
+            log.info("받은 네이버 authCode: {}", authCode);
+
+            // 네이버에서 토큰 가져오기
+            NaverTokenResponse tokenResponse = naverAuthClient.getToken(authCode);
+            if (tokenResponse == null || tokenResponse.getAccessToken() == null) {
+                throw new IllegalArgumentException("네이버 액세스 토큰을 가져올 수 없습니다.");
+            }
+            log.info("받은 네이버 액세스 토큰: {}", tokenResponse.getAccessToken());
+
+            // 토큰을 이용해 사용자 정보 가져오기
+            NaverUserResponse userResponse = naverAuthClient.getUserInfo(tokenResponse.getAccessToken());
+            if (userResponse == null || userResponse.getResponse() == null) {
+                throw new IllegalArgumentException("네이버 사용자 정보를 가져올 수 없습니다.");
+            }
+            log.info("받은 네이버 사용자 정보: {}", userResponse);
+
+            // 이메일 기준으로 사용자 확인 (기존 회원 목록에 없으면 새로 생성)
+            String email = userResponse.getResponse().getEmail();
+            if (email == null) {
+                throw new IllegalArgumentException("네이버 사용자 이메일 정보가 없습니다.");
+            }
+
+            User user = userRepository.findByEmail(email)
+                    .orElseGet(() -> {
+                        log.info("신규 네이버 사용자 저장: {}", email);
+                        return userRepository.save(User.ofNaver(userResponse));
+                    });
+
+            // JWT 발급
+            String jwtToken = jwtUtil.generateToken(user);
+            log.info("JWT 토큰 발급: {}", jwtToken);
+
+            // 응답 DTO 반환
+            return new AuthCodeResponseDto(jwtToken, user.isProfileIncomplete());
+        } catch (Exception e) {
+            log.error("네이버 로그인 중 오류 발생: {}", e.getMessage(), e);
+            throw new RuntimeException("네이버 로그인 중 오류 발생: " + e.getMessage());
+        }
+
+    }
+}

--- a/src/main/java/com/zb/meeteat/exception/ErrorCode.java
+++ b/src/main/java/com/zb/meeteat/exception/ErrorCode.java
@@ -12,7 +12,8 @@ public enum ErrorCode {
     EMAIL_ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "EMAIL_ALREADY_REGISTERED", "이미 사용 중인 이메일입니다."),
     NICKNAME_ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "NICKNAME_ALREADY_REGISTERED", "이미 사용 중인 닉네임입니다."),
     USER_SCHEDULED_FOR_DELETION(HttpStatus.FORBIDDEN, "USER_SCHEDULED_FOR_DELETION", "해당 계정은 탈퇴 예정 상태입니다."),
-    BAD_REQUEST(HttpStatus.BAD_REQUEST, "BAD_REQUEST", "잘못된 요청입니다.");
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "BAD_REQUEST", "잘못된 요청입니다."),
+    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "INVALID_TOKEN", "유효하지 않은 토큰입니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/zb/meeteat/jwt/JwtFilter.java
+++ b/src/main/java/com/zb/meeteat/jwt/JwtFilter.java
@@ -1,0 +1,39 @@
+package com.zb.meeteat.jwt;
+
+import com.zb.meeteat.exception.CustomException;
+import com.zb.meeteat.exception.ErrorCode;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.lang.NonNull;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request,
+                                    @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain chain)
+            throws ServletException, IOException {
+
+
+        String token = request.getHeader("Authorization");
+
+        if (token != null && token.startsWith("Bearer ")) {
+            String jwt = token.replace("Bearer ", "");
+
+            if (jwtUtil.isBlacklisted(jwt)) {
+                throw new CustomException(ErrorCode.INVALID_TOKEN);
+            }
+        }
+
+        chain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/zb/meeteat/jwt/JwtUtil.java
+++ b/src/main/java/com/zb/meeteat/jwt/JwtUtil.java
@@ -1,24 +1,31 @@
 package com.zb.meeteat.jwt;
 
 import com.zb.meeteat.domain.user.entity.User;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
 
 import javax.crypto.SecretKey;
 import java.util.Base64;
 import java.util.Date;
+import java.util.concurrent.TimeUnit;
 
-@Component
+@Slf4j
+@Service
 public class JwtUtil {
 
+    private final RedisTemplate<String, String> redisTemplate;
     private final SecretKey key;
     private final long EXPIRATION_TIME = 1000 * 60 * 60 * 24; // 24시간 유지
 
-    public JwtUtil(@Value("${spring.jwt.secret}") String secretKey) {
+    public JwtUtil(@Value("${spring.jwt.secret}") String secretKey, RedisTemplate<String, String> redisTemplate) {
+        this.redisTemplate = redisTemplate;
         try {
-            // Base64 디코딩 시도 (getBytes 제거)
             byte[] decodedKey = Base64.getDecoder().decode(secretKey);
             this.key = Keys.hmacShaKeyFor(decodedKey);
         } catch (IllegalArgumentException e) {
@@ -28,11 +35,54 @@ public class JwtUtil {
 
     public String generateToken(User user) {
         return Jwts.builder()
-                .subject(user.getEmail())
-                .issuedAt(new Date())
-                .expiration(new Date(System.currentTimeMillis() + EXPIRATION_TIME))
+                .setSubject(user.getEmail())
+                .claim("userId", user.getId())
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION_TIME))
                 .signWith(key)
                 .compact();
+    }
+
+    public Long getUserId(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("userId", Long.class);
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            if (isBlacklisted(token)) {
+                log.warn("블랙리스트에 등록된 토큰입니다: {}", token);
+                return false;
+            }
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            log.warn("JWT 검증 실패: {} - {}", token, e.getMessage());
+            return false;
+        }
+    }
+
+    public void blacklistToken(String token) {
+        long expiration = Math.max(getExpiration(token), 1000);
+        redisTemplate.opsForValue().set(token, "blacklisted", expiration, TimeUnit.MILLISECONDS);
+    }
+
+    public long getExpiration(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        return claims.getExpiration().getTime() - System.currentTimeMillis();
+    }
+
+    public boolean isBlacklisted(String token) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(token));
     }
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,4 +31,8 @@ naver.auth.client-id=${NAVER_CLIENT_ID}
 naver.auth.client-secret=${NAVER_CLIENT_SECRET}
 naver.auth.redirect-uri=http://localhost:8080/api/users/signin/naver
 
+# redis
+spring.data.redis.host=localhost
+spring.data.redis.port=6379
+
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,12 +19,12 @@ spring.jpa.properties.hibernate.format_sql=true
 #spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 # jwt
 spring.jwt.secret=${JWT_SECRET_KEY}
-# ??? OAuth ?? ??
+# Kakao OAuth
 kakao.auth.token-url=https://kauth.kakao.com/oauth/token
 kakao.auth.user-info-url=https://kapi.kakao.com/v2/user/me
 kakao.auth.client-id=${KAKAO_CLIENT_ID}
 kakao.auth.redirect-uri=http://localhost:8080/api/users/signin/kakao
-# ??? OAuth ?? ??
+# Naver OAuth
 naver.auth.token-url=https://nid.naver.com/oauth2.0/token
 naver.auth.user-info-url=https://openapi.naver.com/v1/nid/me
 naver.auth.client-id=${NAVER_CLIENT_ID}

--- a/src/test/java/com/zb/meeteat/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/zb/meeteat/domain/user/repository/UserRepositoryTest.java
@@ -13,7 +13,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@SpringBootTest
+@DataJpaTest
 class UserRepositoryTest {
 
     @Autowired


### PR DESCRIPTION
### Pull Request

# [Feature] 로그아웃 Signout 기능 추가 및 JWT 블랙리스트 적용

## 변경사항

## AS-IS 변경 전
- 기존 JWT 기반 인증 시스템에서는 로그아웃을 별도로 처리하지 않음
- 클라이언트가 단순히 JWT 토큰을 폐기하면 로그아웃이 되었다고 가정
- 사용자가 로그아웃 후에도 기존 JWT가 유효하여 보호된 리소스에 접근 가능
- JWT 만료 전까지 사용자가 다시 로그인하지 않아도 지속적으로 요청 가능

## TO-BE 변경 후
- Redis를 활용한 JWT 블랙리스트 관리 기능 추가
  - 로그아웃 시 해당 JWT를 Redis에 저장하여 블랙리스트에 등록
  - 등록된 JWT는 만료 시간 전이라도 서버에서 유효하지 않은 토큰으로 처리
  - 블랙리스트에 등록된 JWT로 요청 시 INVALID_TOKEN 에러 반환

- JWT 필터 JwtFilter에서 블랙리스트 검증 로직 추가
  - 요청이 들어올 때마다 해당 JWT가 블랙리스트에 있는지 검증
  - 블랙리스트에 포함된 토큰이면 400 응답 반환

- 로그아웃 API 추가
  - Authorization 헤더에서 JWT를 추출하여 로그아웃 처리
  - JwtUtil.blacklistToken 호출하여 해당 JWT를 Redis 블랙리스트에 등록
  - 성공 시 200 OK 응답 반환 별도의 성공 메시지 없이 처리

- JWT 관련 유틸리티 JwtUtil 개선
  - blacklistToken JWT를 블랙리스트에 추가하는 메서드
  - isBlacklisted Redis에서 해당 토큰이 블랙리스트에 있는지 검증
  - validateToken 블랙리스트 여부까지 포함하여 JWT 유효성 검사