### PR TITLE
Feat: 비밀번호 변경, 프로필 조회, 닉네임 변경, 한줄소개 변경 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3:3.14.0'
     // Bouncy Castle 암호화 라이브러리
     implementation 'org.bouncycastle:bcprov-jdk18on:1.78'
-    
+
     implementation "org.springframework.boot:spring-boot-starter-hateoas"
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 

--- a/src/main/java/com/zb/meeteat/config/AwsS3Config.java
+++ b/src/main/java/com/zb/meeteat/config/AwsS3Config.java
@@ -10,6 +10,7 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class AwsS3Config {
+
   // S3를 등록한 사람이 전달받은 접속하기 위한 key 값
   @Value("${cloud.aws.credentials.access-key}")
   private String accessKey;

--- a/src/main/java/com/zb/meeteat/config/RedisConfig.java
+++ b/src/main/java/com/zb/meeteat/config/RedisConfig.java
@@ -17,11 +17,11 @@ public class RedisConfig {
 
     @Bean
     public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
-        RedisTemplate<String, String> template = new RedisTemplate<>();
-        template.setConnectionFactory(redisConnectionFactory);
-        template.setKeySerializer(new StringRedisSerializer());
-        template.setValueSerializer(new StringRedisSerializer());
-        return template;
+      RedisTemplate<String, String> template = new RedisTemplate<>();
+      template.setConnectionFactory(redisConnectionFactory);
+      template.setKeySerializer(new StringRedisSerializer());
+      template.setValueSerializer(new StringRedisSerializer());
+      return template;
     }
 
 }

--- a/src/main/java/com/zb/meeteat/config/RedisConfig.java
+++ b/src/main/java/com/zb/meeteat/config/RedisConfig.java
@@ -23,4 +23,5 @@ public class RedisConfig {
         template.setValueSerializer(new StringRedisSerializer());
         return template;
     }
+
 }

--- a/src/main/java/com/zb/meeteat/config/SecurityConfig.java
+++ b/src/main/java/com/zb/meeteat/config/SecurityConfig.java
@@ -42,7 +42,7 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers(HttpMethod.POST, "/api/users/signup", "/api/users/signin").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/users/signup", "/api/users/signin", "/api/users/signin/*").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/users/change-password").authenticated() // 인증 필요
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/zb/meeteat/config/SecurityConfig.java
+++ b/src/main/java/com/zb/meeteat/config/SecurityConfig.java
@@ -15,8 +15,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 /**
- * 보안 설정을 위한 클래스
- * 비밀번호 암호화를 위해 BCryptPasswordEncoder를 빈으로 등록
+ * 보안 설정을 위한 클래스 비밀번호 암호화를 위해 BCryptPasswordEncoder를 빈으로 등록
  */
 
 @Configuration
@@ -24,31 +23,33 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    private final JwtFilter jwtFilter;
+  private final JwtFilter jwtFilter;
 
-    /**
-     * 비밀번호를 안전하게 암호화하기 위한 PasswordEncoder 빈 등록
-     *
-     * @return BCryptPasswordEncoder 인스턴스
-     */
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
+  /**
+   * 비밀번호를 안전하게 암호화하기 위한 PasswordEncoder 빈 등록
+   *
+   * @return BCryptPasswordEncoder 인스턴스
+   */
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
 
-    @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        http
-                .csrf(AbstractHttpConfigurer::disable)
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers(HttpMethod.POST, "/api/users/signup", "/api/users/signin", "/api/users/signin/*").permitAll()
-                        .requestMatchers(HttpMethod.POST, "/api/users/change-password").authenticated() // 인증 필요
-                        .anyRequest().authenticated()
-                )
-                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class); // JWT 필터 추가
+  @Bean
+  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    http
+        .csrf(AbstractHttpConfigurer::disable)
+        .sessionManagement(
+            session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        .authorizeHttpRequests(authorize -> authorize
+            .requestMatchers(HttpMethod.POST, "/api/users/signup", "/api/users/signin",
+                "/api/users/signin/*").permitAll()
+            .requestMatchers(HttpMethod.POST, "/api/users/change-password").authenticated() // 인증 필요
+            .anyRequest().authenticated()
+        )
+        .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class); // JWT 필터 추가
 
-        return http.build();
-    }
+    return http.build();
+  }
 
 }

--- a/src/main/java/com/zb/meeteat/domain/matching/entity/Matching.java
+++ b/src/main/java/com/zb/meeteat/domain/matching/entity/Matching.java
@@ -24,6 +24,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "matching")
 public class Matching {
+
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;  // 매칭 모임 아이디

--- a/src/main/java/com/zb/meeteat/domain/matching/entity/MatchingHistory.java
+++ b/src/main/java/com/zb/meeteat/domain/matching/entity/MatchingHistory.java
@@ -25,6 +25,7 @@ import lombok.Setter;
 @Entity
 @Table(name = "matchinghistory")
 public class MatchingHistory {
+
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;  // 매칭 내역 아이디

--- a/src/main/java/com/zb/meeteat/domain/restaurant/controller/RestaurantController.java
+++ b/src/main/java/com/zb/meeteat/domain/restaurant/controller/RestaurantController.java
@@ -27,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/restaurants")
 public class RestaurantController {
+
   private final RestaurantService restaurantService;
   private final JwtUtil jwtUtil;
 
@@ -59,7 +60,7 @@ public class RestaurantController {
   }
 
   @PostMapping("/review")
-  public ResponseEntity createReview (
+  public ResponseEntity createReview(
       @RequestHeader("Authorization") String token,
       @ModelAttribute @Valid CreateReviewRequest req) throws UserCustomException {
     // 토큰에서 userId 추출
@@ -77,6 +78,7 @@ public class RestaurantController {
   ) {
 
     jwtUtil.validateToken(token);
-    return ResponseEntity.ok(restaurantService.getMyReviewByMatching(Long.parseLong(matchingHistoryId)));
+    return ResponseEntity.ok(
+        restaurantService.getMyReviewByMatching(Long.parseLong(matchingHistoryId)));
   }
 }

--- a/src/main/java/com/zb/meeteat/domain/restaurant/dto/RestaurantResponse.java
+++ b/src/main/java/com/zb/meeteat/domain/restaurant/dto/RestaurantResponse.java
@@ -13,6 +13,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class RestaurantResponse {
+
   private Long id;
   private Long kakaomaps_id;
   private String place_name;

--- a/src/main/java/com/zb/meeteat/domain/restaurant/dto/SearchRequest.java
+++ b/src/main/java/com/zb/meeteat/domain/restaurant/dto/SearchRequest.java
@@ -15,6 +15,7 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor
 public class SearchRequest {
+
   @NotNull
   @Pattern(regexp = "^(서울|부산|대구|인천|광주|대전|울산|세종|경기|강원|충북|충남|전북|전남|경북|경남|제주)$",
       message = "지역는 서울,부산,대구,인천,광주,대전,울산,세종,경기,강원,충북,충남,전북,전남,경북,경남,제주 만 검색 가능합니다.")

--- a/src/main/java/com/zb/meeteat/domain/restaurant/entity/Restaurant.java
+++ b/src/main/java/com/zb/meeteat/domain/restaurant/entity/Restaurant.java
@@ -19,6 +19,7 @@ import lombok.Setter;
 @Entity
 @Table(name = "restaurant")
 public class Restaurant {
+
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;

--- a/src/main/java/com/zb/meeteat/domain/restaurant/repository/RestaurantRepository.java
+++ b/src/main/java/com/zb/meeteat/domain/restaurant/repository/RestaurantRepository.java
@@ -10,34 +10,37 @@ import org.springframework.data.repository.query.Param;
 
 public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
 
-  @Query(value = "SELECT r.id, r.kakaomaps_id, r.place_name, r.phone, r.y, r.x, r.road_address_name, "
-      + "r.category_name, r.rating, COALESCE(NULLIF(rr.img_url, ''), '') as thumbnail "
-      + "FROM Restaurant r LEFT JOIN RestaurantReview rr ON r.id = rr.restaurant_id "
-      + "WHERE r.id = :restaurantId "
-      + "GROUP BY r.id ORDER BY rr.id DESC", nativeQuery = true)
+  @Query(value =
+      "SELECT r.id, r.kakaomaps_id, r.place_name, r.phone, r.y, r.x, r.road_address_name, "
+          + "r.category_name, r.rating, COALESCE(NULLIF(rr.img_url, ''), '') as thumbnail "
+          + "FROM Restaurant r LEFT JOIN RestaurantReview rr ON r.id = rr.restaurant_id "
+          + "WHERE r.id = :restaurantId "
+          + "GROUP BY r.id ORDER BY rr.id DESC", nativeQuery = true)
   RestaurantResponse getRestaurantById(Long restaurantId);
 
   // 지역, 카테고리명, 장소명
-  @Query(value = "SELECT r.id, r.kakaomaps_id, r.place_name, r.phone, r.y, r.x, r.road_address_name, "
-      + "r.category_name, r.rating, COALESCE(NULLIF(rr.img_url, ''), '') as thumbnail "
-      + "FROM Restaurant r LEFT JOIN RestaurantReview rr ON r.id = rr.restaurant_id "
-      + "WHERE r.road_address_name LIKE %:region% "
-      + "AND r.place_name LIKE %:placeName% "
-      + "AND r.category_name LIKE %:categoryName% "
-      + "GROUP BY r.id ORDER BY rr.id DESC", nativeQuery = true)
+  @Query(value =
+      "SELECT r.id, r.kakaomaps_id, r.place_name, r.phone, r.y, r.x, r.road_address_name, "
+          + "r.category_name, r.rating, COALESCE(NULLIF(rr.img_url, ''), '') as thumbnail "
+          + "FROM Restaurant r LEFT JOIN RestaurantReview rr ON r.id = rr.restaurant_id "
+          + "WHERE r.road_address_name LIKE %:region% "
+          + "AND r.place_name LIKE %:placeName% "
+          + "AND r.category_name LIKE %:categoryName% "
+          + "GROUP BY r.id ORDER BY rr.id DESC", nativeQuery = true)
   Page<RestaurantResponse> getRestaurantByRegionAndCategoryNameAndPlaceName(
       String region, String placeName, String categoryName, Pageable pageable);
 
   // 지역, 장소명, 카테고리명, 거리순-오름차순 정렬
-  @Query(value = "SELECT r.id, r.kakaomaps_id, r.place_name, r.phone, r.y, r.x, r.road_address_name, "
-      + "r.category_name, r.rating, COALESCE(NULLIF(rr.img_url, ''), '') as thumbnail "
-      + "FROM Restaurant r LEFT JOIN RestaurantReview rr ON r.id = rr.restaurant_id "
-      + "WHERE r.road_address_name LIKE %:region% "
-      + "AND r.place_name LIKE %:placeName% "
-      + "AND r.category_name LIKE %:categoryName% "
-      + "GROUP BY r.id ORDER by "
-      + "(6371 * acos(cos(radians(:userLat)) * cos(radians(r.y)) * cos(radians(r.x) - radians(:userLon)) + sin(radians(:userLat)) * sin(radians(r.y)))) ASC, rr.id DESC"
-  , nativeQuery = true)
+  @Query(value =
+      "SELECT r.id, r.kakaomaps_id, r.place_name, r.phone, r.y, r.x, r.road_address_name, "
+          + "r.category_name, r.rating, COALESCE(NULLIF(rr.img_url, ''), '') as thumbnail "
+          + "FROM Restaurant r LEFT JOIN RestaurantReview rr ON r.id = rr.restaurant_id "
+          + "WHERE r.road_address_name LIKE %:region% "
+          + "AND r.place_name LIKE %:placeName% "
+          + "AND r.category_name LIKE %:categoryName% "
+          + "GROUP BY r.id ORDER by "
+          + "(6371 * acos(cos(radians(:userLat)) * cos(radians(r.y)) * cos(radians(r.x) - radians(:userLon)) + sin(radians(:userLat)) * sin(radians(r.y)))) ASC, rr.id DESC"
+      , nativeQuery = true)
   Page<RestaurantResponse> getRestaurantByRegionAndPlaceNameAndCategoryNameOrderByDistance(
       @Param("userLat") double y,
       @Param("userLon") double x,
@@ -47,13 +50,14 @@ public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
       Pageable pageable);
 
   // 지역, 장소명, 카테고리명, 평점순-내림차순 정렬
-  @Query(value = "SELECT r.id, r.kakaomaps_id, r.place_name, r.phone, r.y, r.x, r.road_address_name, "
-      + "r.category_name, r.rating, COALESCE(NULLIF(rr.img_url, ''), '') as thumbnail "
-      + "FROM Restaurant r LEFT JOIN RestaurantReview rr ON r.id = rr.restaurant_id "
-      + "WHERE r.road_address_name LIKE %:region% "
-      + "AND r.place_name LIKE %:placeName% "
-      + "AND r.category_name LIKE %:categoryName% "
-      + "GROUP BY r.id ORDER by r.rating DESC", nativeQuery = true)
+  @Query(value =
+      "SELECT r.id, r.kakaomaps_id, r.place_name, r.phone, r.y, r.x, r.road_address_name, "
+          + "r.category_name, r.rating, COALESCE(NULLIF(rr.img_url, ''), '') as thumbnail "
+          + "FROM Restaurant r LEFT JOIN RestaurantReview rr ON r.id = rr.restaurant_id "
+          + "WHERE r.road_address_name LIKE %:region% "
+          + "AND r.place_name LIKE %:placeName% "
+          + "AND r.category_name LIKE %:categoryName% "
+          + "GROUP BY r.id ORDER by r.rating DESC", nativeQuery = true)
   Page<RestaurantResponse> getRestaurantByRegionAndPlaceNameAndCategoryNameOrderByRatingDesc(
       @Param("region") String region,
       @Param("placeName") String placeName,

--- a/src/main/java/com/zb/meeteat/domain/restaurant/service/RestaurantService.java
+++ b/src/main/java/com/zb/meeteat/domain/restaurant/service/RestaurantService.java
@@ -12,13 +12,9 @@ import com.zb.meeteat.domain.restaurant.repository.RestaurantRepository;
 import com.zb.meeteat.domain.restaurant.repository.RestaurantReviewRepository;
 import com.zb.meeteat.domain.user.entity.User;
 import com.zb.meeteat.domain.user.repository.UserRepository;
-import com.zb.meeteat.exception.UserCustomException;
+import com.zb.meeteat.exception.CustomException;
 import com.zb.meeteat.exception.ErrorCode;
-import java.time.Duration;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+import com.zb.meeteat.exception.UserCustomException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -27,139 +23,145 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class RestaurantService {
 
-  private final S3ImageUpload s3ImageUpload;
-  private final RestaurantRepository restaurantRepository;
-  private final RestaurantReviewRepository restaurantReviewRepository;
-  private final UserRepository userRepository;
-  private final MatchingHistoryRepository matchingHistoryRepository;
-  private static int MAX_FILE_COUNT = 7;
-  private static int AFTER_MATCHING_TIME = 2;
+    private final S3ImageUpload s3ImageUpload;
+    private final RestaurantRepository restaurantRepository;
+    private final RestaurantReviewRepository restaurantReviewRepository;
+    private final UserRepository userRepository;
+    private final MatchingHistoryRepository matchingHistoryRepository;
+    private static int MAX_FILE_COUNT = 7;
+    private static int AFTER_MATCHING_TIME = 2;
 
-  public Page<RestaurantResponse> getRestaurantList(SearchRequest search) {
+    public Page<RestaurantResponse> getRestaurantList(SearchRequest search) {
 
-    String categoryName = search.getCategoryName().equals("전체") ? "" : search.getCategoryName();
-    search.setCategoryName(categoryName);
+        String categoryName = search.getCategoryName().equals("전체") ? "" : search.getCategoryName();
+        search.setCategoryName(categoryName);
 
-    // Pageable 객체 생성 (페이지, 사이즈, 정렬 방식)
-    Pageable pageable = PageRequest.of(search.getPage(), search.getSize());
+        // Pageable 객체 생성 (페이지, 사이즈, 정렬 방식)
+        Pageable pageable = PageRequest.of(search.getPage(), search.getSize());
 
-    // 정렬 기준에 따라 쿼리 메소드 실행
-    Page<RestaurantResponse> restaurants = Page.empty();
+        // 정렬 기준에 따라 쿼리 메소드 실행
+        Page<RestaurantResponse> restaurants = Page.empty();
 
-    if ("RATING".equals(search.getSorted())) {
-      restaurants = restaurantRepository.getRestaurantByRegionAndPlaceNameAndCategoryNameOrderByRatingDesc(
-          search.getRegion(),
-          search.getPlaceName(),
-          search.getCategoryName(),
-          pageable);
-    } else if ("DISTANCE".equals(search.getSorted())) {
-      if (Double.isNaN(search.getUserX()) || Double.isNaN(search.getUserX())) {
-        throw new UserCustomException(ErrorCode.USER_LOCATION_NOT_PROVIDED);
-      }
+        if ("RATING".equals(search.getSorted())) {
+            restaurants = restaurantRepository.getRestaurantByRegionAndPlaceNameAndCategoryNameOrderByRatingDesc(
+                    search.getRegion(),
+                    search.getPlaceName(),
+                    search.getCategoryName(),
+                    pageable);
+        } else if ("DISTANCE".equals(search.getSorted())) {
+            if (Double.isNaN(search.getUserX()) || Double.isNaN(search.getUserX())) {
+                throw new CustomException(ErrorCode.USER_LOCATION_NOT_PROVIDED);
+            }
 
-      restaurants = restaurantRepository.getRestaurantByRegionAndPlaceNameAndCategoryNameOrderByDistance(
-          search.getUserY(),
-          search.getUserX(),
-          search.getRegion(),
-          search.getPlaceName(),
-          search.getCategoryName(),
-          pageable);
-    } else {
-      restaurants = restaurantRepository.getRestaurantByRegionAndCategoryNameAndPlaceName(
-          search.getRegion(),
-          search.getPlaceName(),
-          search.getCategoryName(),
-          pageable);
+            restaurants = restaurantRepository.getRestaurantByRegionAndPlaceNameAndCategoryNameOrderByDistance(
+                    search.getUserY(),
+                    search.getUserX(),
+                    search.getRegion(),
+                    search.getPlaceName(),
+                    search.getCategoryName(),
+                    pageable);
+        } else {
+            restaurants = restaurantRepository.getRestaurantByRegionAndCategoryNameAndPlaceName(
+                    search.getRegion(),
+                    search.getPlaceName(),
+                    search.getCategoryName(),
+                    pageable);
+        }
+
+        return restaurants;
     }
 
-    return restaurants;
-  }
-
-  public RestaurantResponse getRestaurant(Long restaurantId) {
-    return restaurantRepository.getRestaurantById(restaurantId);
-  }
-
-  public Page<RestaurantReview> getRestaurantReviews(
-      Long restaurantId, int page, int size) {
-
-    // Pageable 객체 생성 (페이지, 사이즈, 정렬 방식)
-    Pageable pageable = PageRequest.of(page, size);
-
-    return restaurantReviewRepository.getRestaurantReviewByRestaurantId(restaurantId, pageable);
-  }
-
-  public RestaurantReview createReview(Long userId, CreateReviewRequest req) throws UserCustomException {
-
-    // 1. user 정보 가져오기
-    User user = userRepository.findById(userId)
-        .orElseThrow(() -> new UserCustomException(ErrorCode.BAD_REQUEST));
-
-    // 2. 매칭 참석 여부 확인
-    MatchingHistory history = matchingHistoryRepository.findById(req.getMatchingHistoryId())
-        .orElseThrow(() -> new UserCustomException(ErrorCode.BAD_REQUEST));
-
-    Matching matching = history.getMatching();
-    if (matching.getStatus().equals(MatchingStatus.CANCELED)
-        || history.getStatus().equals(MatchingStatus.CANCELED)) {
-      throw new UserCustomException(ErrorCode.REVIEW_NOT_ALLOWED_FOR_CANCELED_MATCHING);
+    public RestaurantResponse getRestaurant(Long restaurantId) {
+        return restaurantRepository.getRestaurantById(restaurantId);
     }
 
-    // 3. 후기 작성 시간 확인 (매칭 약속시간 이후 2시간)
-    LocalDateTime matchingTime = matching.getCreatedAt();
-    LocalDateTime currentTime = LocalDateTime.now();
-    Duration duration = Duration.between(matchingTime, currentTime);
-    if (duration.toHours() < AFTER_MATCHING_TIME) {
-      throw new UserCustomException(ErrorCode.REVIEW_TIME_NOT_EXCEEDED);
+    public Page<RestaurantReview> getRestaurantReviews(
+            Long restaurantId, int page, int size) {
+
+        // Pageable 객체 생성 (페이지, 사이즈, 정렬 방식)
+        Pageable pageable = PageRequest.of(page, size);
+
+        return restaurantReviewRepository.getRestaurantReviewByRestaurantId(restaurantId, pageable);
     }
 
-    // 4. 첨부파일 확인
-    String imageUrls = saveImage(req.getFiles());
+    public RestaurantReview createReview(Long userId, CreateReviewRequest req) throws UserCustomException {
 
-    // 5. 데이터 저장하기
-    RestaurantReview review = RestaurantReview.builder()
-        .rating(req.getRating())
-        .description(req.getDescription())
-        .imgUrl(imageUrls)
-        .matchingHistoryId(req.getMatchingHistoryId())
-        .user(user)
-        .restaurant(matching.getRestaurant())
-        .build();
+        // 1. user 정보 가져오기
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.BAD_REQUEST));
 
-    return restaurantReviewRepository.save(review);
-  }
+        // 2. 매칭 참석 여부 확인
+        MatchingHistory history = matchingHistoryRepository.findById(req.getMatchingHistoryId())
+                .orElseThrow(() -> new CustomException(ErrorCode.BAD_REQUEST));
 
-  public RestaurantReview getMyReviewByMatching(Long matchingHistoryId) {
-    MatchingHistory history = matchingHistoryRepository.findById(matchingHistoryId)
-        .orElseThrow(() -> new UserCustomException(ErrorCode.BAD_REQUEST));
+        Matching matching = history.getMatching();
+        if (matching.getStatus().equals(MatchingStatus.CANCELED)
+                || history.getStatus().equals(MatchingStatus.CANCELED)) {
+            throw new CustomException(ErrorCode.REVIEW_NOT_ALLOWED_FOR_CANCELED_MATCHING);
+        }
 
-    Matching matching = history.getMatching();
-    if (history.getStatus().equals(MatchingStatus.CANCELED) ||
-        matching.getStatus().equals(MatchingStatus.CANCELED)) {
-      throw new UserCustomException(ErrorCode.CANCELED_MATCHING);
+        // 3. 후기 작성 시간 확인 (매칭 약속시간 이후 2시간)
+        LocalDateTime matchingTime = matching.getCreatedAt();
+        LocalDateTime currentTime = LocalDateTime.now();
+        Duration duration = Duration.between(matchingTime, currentTime);
+        if (duration.toHours() < AFTER_MATCHING_TIME) {
+            throw new CustomException(ErrorCode.REVIEW_TIME_NOT_EXCEEDED);
+        }
+
+        // 4. 첨부파일 확인
+        String imageUrls = saveImage(req.getFiles());
+
+        // 5. 데이터 저장하기
+        RestaurantReview review = RestaurantReview.builder()
+                .rating(req.getRating())
+                .description(req.getDescription())
+                .imgUrl(imageUrls)
+                .matchingHistoryId(req.getMatchingHistoryId())
+                .user(user)
+                .restaurant(matching.getRestaurant())
+                .build();
+
+        return restaurantReviewRepository.save(review);
     }
 
-    return restaurantReviewRepository.findRestaurantReviewByMatchingHistoryId(matchingHistoryId);
-  }
+    public RestaurantReview getMyReviewByMatching(Long matchingHistoryId) {
+        MatchingHistory history = matchingHistoryRepository.findById(matchingHistoryId)
+                .orElseThrow(() -> new CustomException(ErrorCode.BAD_REQUEST));
 
-  private String saveImage(MultipartFile[] files) {
-    if (files.length > MAX_FILE_COUNT || files.length < 1
-        || files[0].isEmpty() || Objects.requireNonNull(files[0].getOriginalFilename()).isEmpty()) {
-      return null;
+        Matching matching = history.getMatching();
+        if (history.getStatus().equals(MatchingStatus.CANCELED) ||
+                matching.getStatus().equals(MatchingStatus.CANCELED)) {
+            throw new CustomException(ErrorCode.CANCELED_MATCHING);
+        }
+
+        return restaurantReviewRepository.findRestaurantReviewByMatchingHistoryId(matchingHistoryId);
     }
 
-    List<String> imgUrlList = new ArrayList<String>();
-    for (MultipartFile image : files) {
-      String newFileName = s3ImageUpload.uploadImage(image);
-      imgUrlList.add(newFileName);
-      log.info("➡️ 이미지 저장 :{} - {}", image.getOriginalFilename(), newFileName);
-    }
+    private String saveImage(MultipartFile[] files) {
+        if (files.length > MAX_FILE_COUNT || files.length < 1
+                || files[0].isEmpty() || Objects.requireNonNull(files[0].getOriginalFilename()).isEmpty()) {
+            return null;
+        }
 
-    return String.join(",", imgUrlList);
-  }
+        List<String> imgUrlList = new ArrayList<String>();
+        for (MultipartFile image : files) {
+            String newFileName = s3ImageUpload.uploadImage(image);
+            imgUrlList.add(newFileName);
+            log.info("➡️ 이미지 저장 :{} - {}", image.getOriginalFilename(), newFileName);
+        }
+
+        return String.join(",", imgUrlList);
+    }
 
 }

--- a/src/main/java/com/zb/meeteat/domain/restaurant/service/RestaurantService.java
+++ b/src/main/java/com/zb/meeteat/domain/restaurant/service/RestaurantService.java
@@ -34,134 +34,135 @@ import java.util.Objects;
 @RequiredArgsConstructor
 public class RestaurantService {
 
-    private final S3ImageUpload s3ImageUpload;
-    private final RestaurantRepository restaurantRepository;
-    private final RestaurantReviewRepository restaurantReviewRepository;
-    private final UserRepository userRepository;
-    private final MatchingHistoryRepository matchingHistoryRepository;
-    private static int MAX_FILE_COUNT = 7;
-    private static int AFTER_MATCHING_TIME = 2;
+  private final S3ImageUpload s3ImageUpload;
+  private final RestaurantRepository restaurantRepository;
+  private final RestaurantReviewRepository restaurantReviewRepository;
+  private final UserRepository userRepository;
+  private final MatchingHistoryRepository matchingHistoryRepository;
+  private static int MAX_FILE_COUNT = 7;
+  private static int AFTER_MATCHING_TIME = 2;
 
-    public Page<RestaurantResponse> getRestaurantList(SearchRequest search) {
+  public Page<RestaurantResponse> getRestaurantList(SearchRequest search) {
 
-        String categoryName = search.getCategoryName().equals("전체") ? "" : search.getCategoryName();
-        search.setCategoryName(categoryName);
+    String categoryName = search.getCategoryName().equals("전체") ? "" : search.getCategoryName();
+    search.setCategoryName(categoryName);
 
-        // Pageable 객체 생성 (페이지, 사이즈, 정렬 방식)
-        Pageable pageable = PageRequest.of(search.getPage(), search.getSize());
+    // Pageable 객체 생성 (페이지, 사이즈, 정렬 방식)
+    Pageable pageable = PageRequest.of(search.getPage(), search.getSize());
 
-        // 정렬 기준에 따라 쿼리 메소드 실행
-        Page<RestaurantResponse> restaurants = Page.empty();
+    // 정렬 기준에 따라 쿼리 메소드 실행
+    Page<RestaurantResponse> restaurants = Page.empty();
 
-        if ("RATING".equals(search.getSorted())) {
-            restaurants = restaurantRepository.getRestaurantByRegionAndPlaceNameAndCategoryNameOrderByRatingDesc(
-                    search.getRegion(),
-                    search.getPlaceName(),
-                    search.getCategoryName(),
-                    pageable);
-        } else if ("DISTANCE".equals(search.getSorted())) {
-            if (Double.isNaN(search.getUserX()) || Double.isNaN(search.getUserX())) {
-                throw new CustomException(ErrorCode.USER_LOCATION_NOT_PROVIDED);
-            }
+    if ("RATING".equals(search.getSorted())) {
+      restaurants = restaurantRepository.getRestaurantByRegionAndPlaceNameAndCategoryNameOrderByRatingDesc(
+          search.getRegion(),
+          search.getPlaceName(),
+          search.getCategoryName(),
+          pageable);
+    } else if ("DISTANCE".equals(search.getSorted())) {
+      if (Double.isNaN(search.getUserX()) || Double.isNaN(search.getUserX())) {
+        throw new CustomException(ErrorCode.USER_LOCATION_NOT_PROVIDED);
+      }
 
-            restaurants = restaurantRepository.getRestaurantByRegionAndPlaceNameAndCategoryNameOrderByDistance(
-                    search.getUserY(),
-                    search.getUserX(),
-                    search.getRegion(),
-                    search.getPlaceName(),
-                    search.getCategoryName(),
-                    pageable);
-        } else {
-            restaurants = restaurantRepository.getRestaurantByRegionAndCategoryNameAndPlaceName(
-                    search.getRegion(),
-                    search.getPlaceName(),
-                    search.getCategoryName(),
-                    pageable);
-        }
-
-        return restaurants;
+      restaurants = restaurantRepository.getRestaurantByRegionAndPlaceNameAndCategoryNameOrderByDistance(
+          search.getUserY(),
+          search.getUserX(),
+          search.getRegion(),
+          search.getPlaceName(),
+          search.getCategoryName(),
+          pageable);
+    } else {
+      restaurants = restaurantRepository.getRestaurantByRegionAndCategoryNameAndPlaceName(
+          search.getRegion(),
+          search.getPlaceName(),
+          search.getCategoryName(),
+          pageable);
     }
 
-    public RestaurantResponse getRestaurant(Long restaurantId) {
-        return restaurantRepository.getRestaurantById(restaurantId);
+    return restaurants;
+  }
+
+  public RestaurantResponse getRestaurant(Long restaurantId) {
+    return restaurantRepository.getRestaurantById(restaurantId);
+  }
+
+  public Page<RestaurantReview> getRestaurantReviews(
+      Long restaurantId, int page, int size) {
+
+    // Pageable 객체 생성 (페이지, 사이즈, 정렬 방식)
+    Pageable pageable = PageRequest.of(page, size);
+
+    return restaurantReviewRepository.getRestaurantReviewByRestaurantId(restaurantId, pageable);
+  }
+
+  public RestaurantReview createReview(Long userId, CreateReviewRequest req)
+      throws UserCustomException {
+
+    // 1. user 정보 가져오기
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new CustomException(ErrorCode.BAD_REQUEST));
+
+    // 2. 매칭 참석 여부 확인
+    MatchingHistory history = matchingHistoryRepository.findById(req.getMatchingHistoryId())
+        .orElseThrow(() -> new CustomException(ErrorCode.BAD_REQUEST));
+
+    Matching matching = history.getMatching();
+    if (matching.getStatus().equals(MatchingStatus.CANCELED)
+        || history.getStatus().equals(MatchingStatus.CANCELED)) {
+      throw new CustomException(ErrorCode.REVIEW_NOT_ALLOWED_FOR_CANCELED_MATCHING);
     }
 
-    public Page<RestaurantReview> getRestaurantReviews(
-            Long restaurantId, int page, int size) {
-
-        // Pageable 객체 생성 (페이지, 사이즈, 정렬 방식)
-        Pageable pageable = PageRequest.of(page, size);
-
-        return restaurantReviewRepository.getRestaurantReviewByRestaurantId(restaurantId, pageable);
+    // 3. 후기 작성 시간 확인 (매칭 약속시간 이후 2시간)
+    LocalDateTime matchingTime = matching.getCreatedAt();
+    LocalDateTime currentTime = LocalDateTime.now();
+    Duration duration = Duration.between(matchingTime, currentTime);
+    if (duration.toHours() < AFTER_MATCHING_TIME) {
+      throw new CustomException(ErrorCode.REVIEW_TIME_NOT_EXCEEDED);
     }
 
-    public RestaurantReview createReview(Long userId, CreateReviewRequest req) throws UserCustomException {
+    // 4. 첨부파일 확인
+    String imageUrls = saveImage(req.getFiles());
 
-        // 1. user 정보 가져오기
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.BAD_REQUEST));
+    // 5. 데이터 저장하기
+    RestaurantReview review = RestaurantReview.builder()
+        .rating(req.getRating())
+        .description(req.getDescription())
+        .imgUrl(imageUrls)
+        .matchingHistoryId(req.getMatchingHistoryId())
+        .user(user)
+        .restaurant(matching.getRestaurant())
+        .build();
 
-        // 2. 매칭 참석 여부 확인
-        MatchingHistory history = matchingHistoryRepository.findById(req.getMatchingHistoryId())
-                .orElseThrow(() -> new CustomException(ErrorCode.BAD_REQUEST));
+    return restaurantReviewRepository.save(review);
+  }
 
-        Matching matching = history.getMatching();
-        if (matching.getStatus().equals(MatchingStatus.CANCELED)
-                || history.getStatus().equals(MatchingStatus.CANCELED)) {
-            throw new CustomException(ErrorCode.REVIEW_NOT_ALLOWED_FOR_CANCELED_MATCHING);
-        }
+  public RestaurantReview getMyReviewByMatching(Long matchingHistoryId) {
+    MatchingHistory history = matchingHistoryRepository.findById(matchingHistoryId)
+        .orElseThrow(() -> new CustomException(ErrorCode.BAD_REQUEST));
 
-        // 3. 후기 작성 시간 확인 (매칭 약속시간 이후 2시간)
-        LocalDateTime matchingTime = matching.getCreatedAt();
-        LocalDateTime currentTime = LocalDateTime.now();
-        Duration duration = Duration.between(matchingTime, currentTime);
-        if (duration.toHours() < AFTER_MATCHING_TIME) {
-            throw new CustomException(ErrorCode.REVIEW_TIME_NOT_EXCEEDED);
-        }
-
-        // 4. 첨부파일 확인
-        String imageUrls = saveImage(req.getFiles());
-
-        // 5. 데이터 저장하기
-        RestaurantReview review = RestaurantReview.builder()
-                .rating(req.getRating())
-                .description(req.getDescription())
-                .imgUrl(imageUrls)
-                .matchingHistoryId(req.getMatchingHistoryId())
-                .user(user)
-                .restaurant(matching.getRestaurant())
-                .build();
-
-        return restaurantReviewRepository.save(review);
+    Matching matching = history.getMatching();
+    if (history.getStatus().equals(MatchingStatus.CANCELED) ||
+        matching.getStatus().equals(MatchingStatus.CANCELED)) {
+      throw new CustomException(ErrorCode.CANCELED_MATCHING);
     }
 
-    public RestaurantReview getMyReviewByMatching(Long matchingHistoryId) {
-        MatchingHistory history = matchingHistoryRepository.findById(matchingHistoryId)
-                .orElseThrow(() -> new CustomException(ErrorCode.BAD_REQUEST));
+    return restaurantReviewRepository.findRestaurantReviewByMatchingHistoryId(matchingHistoryId);
+  }
 
-        Matching matching = history.getMatching();
-        if (history.getStatus().equals(MatchingStatus.CANCELED) ||
-                matching.getStatus().equals(MatchingStatus.CANCELED)) {
-            throw new CustomException(ErrorCode.CANCELED_MATCHING);
-        }
-
-        return restaurantReviewRepository.findRestaurantReviewByMatchingHistoryId(matchingHistoryId);
+  private String saveImage(MultipartFile[] files) {
+    if (files.length > MAX_FILE_COUNT || files.length < 1
+        || files[0].isEmpty() || Objects.requireNonNull(files[0].getOriginalFilename()).isEmpty()) {
+      return null;
     }
 
-    private String saveImage(MultipartFile[] files) {
-        if (files.length > MAX_FILE_COUNT || files.length < 1
-                || files[0].isEmpty() || Objects.requireNonNull(files[0].getOriginalFilename()).isEmpty()) {
-            return null;
-        }
-
-        List<String> imgUrlList = new ArrayList<String>();
-        for (MultipartFile image : files) {
-            String newFileName = s3ImageUpload.uploadImage(image);
-            imgUrlList.add(newFileName);
-            log.info("➡️ 이미지 저장 :{} - {}", image.getOriginalFilename(), newFileName);
-        }
-
-        return String.join(",", imgUrlList);
+    List<String> imgUrlList = new ArrayList<String>();
+    for (MultipartFile image : files) {
+      String newFileName = s3ImageUpload.uploadImage(image);
+      imgUrlList.add(newFileName);
+      log.info("➡️ 이미지 저장 :{} - {}", image.getOriginalFilename(), newFileName);
     }
+
+    return String.join(",", imgUrlList);
+  }
 
 }

--- a/src/main/java/com/zb/meeteat/domain/restaurant/service/S3ImageUpload.java
+++ b/src/main/java/com/zb/meeteat/domain/restaurant/service/S3ImageUpload.java
@@ -3,7 +3,7 @@ package com.zb.meeteat.domain.restaurant.service;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.zb.meeteat.exception.UserCustomException;
+import com.zb.meeteat.exception.CustomException;
 import com.zb.meeteat.exception.ErrorCode;
 import java.io.IOException;
 import java.io.InputStream;
@@ -36,7 +36,7 @@ public class S3ImageUpload {
       amazonS3.putObject(bucket, newFileName, inputStream, objectMetadata);
       return newFileName;
     } catch (IOException e) {
-      throw new UserCustomException(ErrorCode.FAIL_FILE_UPLOAD);
+      throw new CustomException(ErrorCode.FAIL_FILE_UPLOAD);
     }
   }
 
@@ -66,7 +66,7 @@ public class S3ImageUpload {
 
     String extension = fileName.substring(fileName.lastIndexOf(".") + 1).toLowerCase();
     if (!ALLOWED_EXTENSIONS.contains(extension)) {
-      throw new UserCustomException(ErrorCode.INVALID_FILE_FORMAT);
+      throw new CustomException(ErrorCode.INVALID_FILE_FORMAT);
     }
 
     return extention;

--- a/src/main/java/com/zb/meeteat/domain/user/controller/AuthController.java
+++ b/src/main/java/com/zb/meeteat/domain/user/controller/AuthController.java
@@ -1,11 +1,9 @@
 package com.zb.meeteat.domain.user.controller;
 
-import com.zb.meeteat.domain.user.dto.AuthCodeResponseDto;
-import com.zb.meeteat.domain.user.dto.ChangePasswordRequest;
-import com.zb.meeteat.domain.user.dto.SigninRequestDto;
-import com.zb.meeteat.domain.user.dto.SignupRequestDto;
+import com.zb.meeteat.domain.user.dto.*;
 import com.zb.meeteat.domain.user.service.AuthService;
 import com.zb.meeteat.domain.user.service.SocialAuthService;
+import com.zb.meeteat.domain.user.service.UserService;
 import com.zb.meeteat.security.UserDetailsImpl;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +23,7 @@ public class AuthController {
 
     private final AuthService authService;
     private final SocialAuthService socialAuthService;
+    private final UserService userService;
 
     // 회원가입
     @PostMapping("/signup")
@@ -81,4 +80,34 @@ public class AuthController {
         return ResponseEntity.ok(Map.of("message", "비밀번호가 성공적으로 변경되었습니다."));
     }
 
+    // 프로필 조회
+    @GetMapping("/profile")
+    public ResponseEntity<UserProfileResponse> getProfile(
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        UserProfileResponse profile = userService.getUserProfile(userDetails.getUser().getId());
+        return ResponseEntity.ok(profile);
+    }
+
+    // 닉네임 변경
+    @PatchMapping("/profile/nickname")
+    public ResponseEntity<String> updateNickname(
+            @Valid @RequestBody UpdateNicknameRequest request,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        userService.updateNickname(userDetails.getUser(), request.getNickname());
+        return ResponseEntity.ok("닉네임이 성공적으로 변경되었습니다.");
+    }
+
+    // 한줄 소개 변경
+    @PatchMapping("/profile/introduce")
+    public ResponseEntity<String> updateIntroduce(
+            @Valid @RequestBody UpdateIntroduceRequest request,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        userService.updateIntroduce(userDetails.getUser(), request.getIntroduce());
+        return ResponseEntity.ok("한줄 소개가 성공적으로 변경되었습니다.");
+    }
+
+
 }
+

--- a/src/main/java/com/zb/meeteat/domain/user/controller/AuthController.java
+++ b/src/main/java/com/zb/meeteat/domain/user/controller/AuthController.java
@@ -1,14 +1,18 @@
 package com.zb.meeteat.domain.user.controller;
 
 import com.zb.meeteat.domain.user.dto.AuthCodeResponseDto;
+import com.zb.meeteat.domain.user.dto.ChangePasswordRequest;
 import com.zb.meeteat.domain.user.dto.SigninRequestDto;
 import com.zb.meeteat.domain.user.dto.SignupRequestDto;
 import com.zb.meeteat.domain.user.service.AuthService;
 import com.zb.meeteat.domain.user.service.SocialAuthService;
+import com.zb.meeteat.security.UserDetailsImpl;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -60,5 +64,21 @@ public class AuthController {
         return ResponseEntity.ok().build();
     }
 
+    // 비밀번호 변경
+    @PostMapping("/change-password")
+    public ResponseEntity<?> changePassword(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @Valid @RequestBody ChangePasswordRequest request) {
+
+        log.info("Received request: {}", request);
+        log.info("changePassword 요청 도착!"); // 요청이 컨트롤러까지 도달하는지 확인
+        log.info("요청한 사용자: {}", userDetails != null ? userDetails.getUsername() : "NULL");
+        log.info("입력된 현재 비밀번호: {}", request.getCurrentPassword());
+
+        assert userDetails != null;
+        authService.changePassword(userDetails.getUser(), request);
+
+        return ResponseEntity.ok(Map.of("message", "비밀번호가 성공적으로 변경되었습니다."));
+    }
 
 }

--- a/src/main/java/com/zb/meeteat/domain/user/controller/AuthController.java
+++ b/src/main/java/com/zb/meeteat/domain/user/controller/AuthController.java
@@ -1,19 +1,30 @@
 package com.zb.meeteat.domain.user.controller;
 
-import com.zb.meeteat.domain.user.dto.*;
+import com.zb.meeteat.domain.user.dto.AuthCodeResponseDto;
+import com.zb.meeteat.domain.user.dto.ChangePasswordRequest;
+import com.zb.meeteat.domain.user.dto.SigninRequestDto;
+import com.zb.meeteat.domain.user.dto.SignupRequestDto;
+import com.zb.meeteat.domain.user.dto.UpdateIntroduceRequest;
+import com.zb.meeteat.domain.user.dto.UpdateNicknameRequest;
+import com.zb.meeteat.domain.user.dto.UserProfileResponse;
 import com.zb.meeteat.domain.user.service.AuthService;
 import com.zb.meeteat.domain.user.service.SocialAuthService;
 import com.zb.meeteat.domain.user.service.UserService;
 import com.zb.meeteat.security.UserDetailsImpl;
 import jakarta.validation.Valid;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.Map;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
@@ -21,92 +32,93 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class AuthController {
 
-    private final AuthService authService;
-    private final SocialAuthService socialAuthService;
-    private final UserService userService;
+  private final AuthService authService;
+  private final SocialAuthService socialAuthService;
+  private final UserService userService;
 
-    // 회원가입
-    @PostMapping("/signup")
-    public ResponseEntity<String> signup(@Valid @RequestBody SignupRequestDto requestDto) {
-        authService.signup(requestDto);
-        return ResponseEntity.ok("회원가입 성공");
+  // 회원가입
+  @PostMapping("/signup")
+  public ResponseEntity<String> signup(@Valid @RequestBody SignupRequestDto requestDto) {
+    authService.signup(requestDto);
+    return ResponseEntity.ok("회원가입 성공");
+  }
+
+  // 이메일 로그인
+  @PostMapping("/signin")
+  public ResponseEntity<AuthCodeResponseDto> signin(
+      @Valid @RequestBody SigninRequestDto requestDto) {
+    return ResponseEntity.ok(authService.signin(requestDto));
+  }
+
+  // 소셜 로그인
+  @PostMapping("/signin/{provider}")
+  public ResponseEntity<AuthCodeResponseDto> socialSignin(
+      @PathVariable String provider,
+      @RequestBody Map<String, String> requestBody) {
+
+    String authCode = requestBody.get("code");
+
+    log.info("받은 authCode: {}", authCode);
+
+    if (authCode == null || authCode.isEmpty()) {
+      throw new IllegalArgumentException("인가 코드가 제공되지 않았습니다.");
     }
 
-    // 이메일 로그인
-    @PostMapping("/signin")
-    public ResponseEntity<AuthCodeResponseDto> signin(@Valid @RequestBody SigninRequestDto requestDto) {
-        return ResponseEntity.ok(authService.signin(requestDto));
-    }
+    AuthCodeResponseDto response = socialAuthService.socialSignin(provider, authCode);
+    return ResponseEntity.ok(response);
+  }
 
-    // 소셜 로그인
-    @PostMapping("/signin/{provider}")
-    public ResponseEntity<AuthCodeResponseDto> socialSignin(
-            @PathVariable String provider,
-            @RequestBody Map<String, String> requestBody) {
+  // 로그 아웃
+  @PostMapping("/signout")
+  public ResponseEntity<Void> signout(@RequestHeader("Authorization") String token) {
+    authService.signout(token);
+    return ResponseEntity.ok().build();
+  }
 
-        String authCode = requestBody.get("code");
+  // 비밀번호 변경
+  @PostMapping("/change-password")
+  public ResponseEntity<?> changePassword(
+      @AuthenticationPrincipal UserDetailsImpl userDetails,
+      @Valid @RequestBody ChangePasswordRequest request) {
 
-        log.info("받은 authCode: {}", authCode);
+    log.info("Received request: {}", request);
+    log.info("changePassword 요청 도착!"); // 요청이 컨트롤러까지 도달하는지 확인
+    log.info("요청한 사용자: {}", userDetails != null ? userDetails.getUsername() : "NULL");
+    log.info("입력된 현재 비밀번호: {}", request.getCurrentPassword());
 
-        if (authCode == null || authCode.isEmpty()) {
-            throw new IllegalArgumentException("인가 코드가 제공되지 않았습니다.");
-        }
+    assert userDetails != null;
+    authService.changePassword(userDetails.getUser(), request);
 
-        AuthCodeResponseDto response = socialAuthService.socialSignin(provider, authCode);
-        return ResponseEntity.ok(response);
-    }
+    return ResponseEntity.ok(Map.of("message", "비밀번호가 성공적으로 변경되었습니다."));
+  }
 
-    // 로그 아웃
-    @PostMapping("/signout")
-    public ResponseEntity<Void> signout(@RequestHeader("Authorization") String token) {
-        authService.signout(token);
-        return ResponseEntity.ok().build();
-    }
+  // 프로필 조회
+  @GetMapping("/profile")
+  public ResponseEntity<UserProfileResponse> getProfile(
+      @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    UserProfileResponse profile = userService.getUserProfile(userDetails.getUser().getId());
+    return ResponseEntity.ok(profile);
+  }
 
-    // 비밀번호 변경
-    @PostMapping("/change-password")
-    public ResponseEntity<?> changePassword(
-            @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @Valid @RequestBody ChangePasswordRequest request) {
+  // 닉네임 변경
+  @PatchMapping("/profile/nickname")
+  public ResponseEntity<String> updateNickname(
+      @Valid @RequestBody UpdateNicknameRequest request,
+      @AuthenticationPrincipal UserDetailsImpl userDetails) {
 
-        log.info("Received request: {}", request);
-        log.info("changePassword 요청 도착!"); // 요청이 컨트롤러까지 도달하는지 확인
-        log.info("요청한 사용자: {}", userDetails != null ? userDetails.getUsername() : "NULL");
-        log.info("입력된 현재 비밀번호: {}", request.getCurrentPassword());
+    userService.updateNickname(userDetails.getUser(), request.getNickname());
+    return ResponseEntity.ok("닉네임이 성공적으로 변경되었습니다.");
+  }
 
-        assert userDetails != null;
-        authService.changePassword(userDetails.getUser(), request);
+  // 한줄 소개 변경
+  @PatchMapping("/profile/introduce")
+  public ResponseEntity<String> updateIntroduce(
+      @Valid @RequestBody UpdateIntroduceRequest request,
+      @AuthenticationPrincipal UserDetailsImpl userDetails) {
 
-        return ResponseEntity.ok(Map.of("message", "비밀번호가 성공적으로 변경되었습니다."));
-    }
-
-    // 프로필 조회
-    @GetMapping("/profile")
-    public ResponseEntity<UserProfileResponse> getProfile(
-            @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        UserProfileResponse profile = userService.getUserProfile(userDetails.getUser().getId());
-        return ResponseEntity.ok(profile);
-    }
-
-    // 닉네임 변경
-    @PatchMapping("/profile/nickname")
-    public ResponseEntity<String> updateNickname(
-            @Valid @RequestBody UpdateNicknameRequest request,
-            @AuthenticationPrincipal UserDetailsImpl userDetails) {
-
-        userService.updateNickname(userDetails.getUser(), request.getNickname());
-        return ResponseEntity.ok("닉네임이 성공적으로 변경되었습니다.");
-    }
-
-    // 한줄 소개 변경
-    @PatchMapping("/profile/introduce")
-    public ResponseEntity<String> updateIntroduce(
-            @Valid @RequestBody UpdateIntroduceRequest request,
-            @AuthenticationPrincipal UserDetailsImpl userDetails) {
-
-        userService.updateIntroduce(userDetails.getUser(), request.getIntroduce());
-        return ResponseEntity.ok("한줄 소개가 성공적으로 변경되었습니다.");
-    }
+    userService.updateIntroduce(userDetails.getUser(), request.getIntroduce());
+    return ResponseEntity.ok("한줄 소개가 성공적으로 변경되었습니다.");
+  }
 
 
 }

--- a/src/main/java/com/zb/meeteat/domain/user/dto/AuthCodeRequestDto.java
+++ b/src/main/java/com/zb/meeteat/domain/user/dto/AuthCodeRequestDto.java
@@ -8,10 +8,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class AuthCodeRequestDto {
 
-    @NotBlank(message = "authCode는 필수 입력 항목입니다.")
-    private String authCode;
+  @NotBlank(message = "authCode는 필수 입력 항목입니다.")
+  private String authCode;
 
-    public AuthCodeRequestDto(String authCode) {
-        this.authCode = authCode;
-    }
+  public AuthCodeRequestDto(String authCode) {
+    this.authCode = authCode;
+  }
 }

--- a/src/main/java/com/zb/meeteat/domain/user/dto/AuthCodeResponseDto.java
+++ b/src/main/java/com/zb/meeteat/domain/user/dto/AuthCodeResponseDto.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class AuthCodeResponseDto {
-    private String accessToken;
-    private boolean needProfileUpdate;
+
+  private String accessToken;
+  private boolean needProfileUpdate;
 
 }

--- a/src/main/java/com/zb/meeteat/domain/user/dto/ChangePasswordRequest.java
+++ b/src/main/java/com/zb/meeteat/domain/user/dto/ChangePasswordRequest.java
@@ -1,0 +1,25 @@
+package com.zb.meeteat.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChangePasswordRequest {
+
+    @NotBlank(message = "현재 비밀번호는 필수 입력 항목입니다.")
+    private String currentPassword;
+
+    @NotBlank(message = "새 비밀번호는 필수 입력 항목입니다.")
+    @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
+    @Pattern(
+            regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$",
+            message = "비밀번호는 최소 8자 이상이며, 영문, 숫자, 특수문자를 각각 하나 이상 포함해야 합니다."
+    )
+    private String newPassword;
+}

--- a/src/main/java/com/zb/meeteat/domain/user/dto/ChangePasswordRequest.java
+++ b/src/main/java/com/zb/meeteat/domain/user/dto/ChangePasswordRequest.java
@@ -18,7 +18,7 @@ public class ChangePasswordRequest {
     @NotBlank(message = "새 비밀번호는 필수 입력 항목입니다.")
     @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
     @Pattern(
-            regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$",
+            regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[\\p{Punct}\\p{S}&&[^\\p{So}]]).{8,}$",
             message = "비밀번호는 최소 8자 이상이며, 영문, 숫자, 특수문자를 각각 하나 이상 포함해야 합니다."
     )
     private String newPassword;

--- a/src/main/java/com/zb/meeteat/domain/user/dto/ChangePasswordRequest.java
+++ b/src/main/java/com/zb/meeteat/domain/user/dto/ChangePasswordRequest.java
@@ -12,14 +12,14 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class ChangePasswordRequest {
 
-    @NotBlank(message = "현재 비밀번호는 필수 입력 항목입니다.")
-    private String currentPassword;
+  @NotBlank(message = "현재 비밀번호는 필수 입력 항목입니다.")
+  private String currentPassword;
 
-    @NotBlank(message = "새 비밀번호는 필수 입력 항목입니다.")
-    @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
-    @Pattern(
-            regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[\\p{Punct}\\p{S}&&[^\\p{So}]]).{8,}$",
-            message = "비밀번호는 최소 8자 이상이며, 영문, 숫자, 특수문자를 각각 하나 이상 포함해야 합니다."
-    )
-    private String newPassword;
+  @NotBlank(message = "새 비밀번호는 필수 입력 항목입니다.")
+  @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
+  @Pattern(
+      regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[\\p{Punct}\\p{S}&&[^\\p{So}]]).{8,}$",
+      message = "비밀번호는 최소 8자 이상이며, 영문, 숫자, 특수문자를 각각 하나 이상 포함해야 합니다."
+  )
+  private String newPassword;
 }

--- a/src/main/java/com/zb/meeteat/domain/user/dto/SigninRequestDto.java
+++ b/src/main/java/com/zb/meeteat/domain/user/dto/SigninRequestDto.java
@@ -11,10 +11,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class SigninRequestDto {
 
-    @Email(message = "유효한 이메일 형식을 입력하세요.")
-    @NotBlank(message = "이메일은 필수 입력 항목입니다.")
-    private String email;
+  @Email(message = "유효한 이메일 형식을 입력하세요.")
+  @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+  private String email;
 
-    @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
-    private String password;
+  @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
+  private String password;
 }

--- a/src/main/java/com/zb/meeteat/domain/user/dto/SignupRequestDto.java
+++ b/src/main/java/com/zb/meeteat/domain/user/dto/SignupRequestDto.java
@@ -7,26 +7,25 @@ import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
 @Builder
 public class SignupRequestDto {
 
-    @Email(message = "유효한 이메일 형식을 입력하세요.")
-    @NotBlank(message = "이메일은 필수 입력 항목입니다.")
-    private String email;
+  @Email(message = "유효한 이메일 형식을 입력하세요.")
+  @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+  private String email;
 
-    @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
-    @Size(min = 8)
-    @Pattern(
-            regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[\\p{Punct}\\p{S}&&[^\\p{So}]]).{8,}$",
-            message = "비밀번호는 최소 8자 이상이며, 영문, 숫자, 특수문자를 각각 하나 이상 포함해야 합니다."
-    )
-    private String password;
+  @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
+  @Size(min = 8)
+  @Pattern(
+      regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[\\p{Punct}\\p{S}&&[^\\p{So}]]).{8,}$",
+      message = "비밀번호는 최소 8자 이상이며, 영문, 숫자, 특수문자를 각각 하나 이상 포함해야 합니다."
+  )
+  private String password;
 
-    @NotBlank(message = "닉네임은 필수 입력 항목입니다.")
-    private String nickname;
+  @NotBlank(message = "닉네임은 필수 입력 항목입니다.")
+  private String nickname;
 
 }

--- a/src/main/java/com/zb/meeteat/domain/user/dto/SignupRequestDto.java
+++ b/src/main/java/com/zb/meeteat/domain/user/dto/SignupRequestDto.java
@@ -21,7 +21,7 @@ public class SignupRequestDto {
     @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
     @Size(min = 8)
     @Pattern(
-            regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$",
+            regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[\\p{Punct}\\p{S}&&[^\\p{So}]]).{8,}$",
             message = "비밀번호는 최소 8자 이상이며, 영문, 숫자, 특수문자를 각각 하나 이상 포함해야 합니다."
     )
     private String password;

--- a/src/main/java/com/zb/meeteat/domain/user/dto/UpdateIntroduceRequest.java
+++ b/src/main/java/com/zb/meeteat/domain/user/dto/UpdateIntroduceRequest.java
@@ -6,6 +6,6 @@ import lombok.Getter;
 @Getter
 public class UpdateIntroduceRequest {
 
-    @Size(max = 50, message = "한줄 소개는 50자 이내로 입력해주세요.")
-    private String introduce;
+  @Size(max = 50, message = "한줄 소개는 50자 이내로 입력해주세요.")
+  private String introduce;
 }

--- a/src/main/java/com/zb/meeteat/domain/user/dto/UpdateIntroduceRequest.java
+++ b/src/main/java/com/zb/meeteat/domain/user/dto/UpdateIntroduceRequest.java
@@ -1,0 +1,11 @@
+package com.zb.meeteat.domain.user.dto;
+
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class UpdateIntroduceRequest {
+
+    @Size(max = 50, message = "한줄 소개는 50자 이내로 입력해주세요.")
+    private String introduce;
+}

--- a/src/main/java/com/zb/meeteat/domain/user/dto/UpdateNicknameRequest.java
+++ b/src/main/java/com/zb/meeteat/domain/user/dto/UpdateNicknameRequest.java
@@ -1,0 +1,13 @@
+package com.zb.meeteat.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+
+@Getter
+public class UpdateNicknameRequest {
+
+    @NotBlank(message = "닉네임은 비워둘 수 없습니다.")
+    @Pattern(regexp = "^[^\\s]+$", message = "닉네임에는 공백이 포함될 수 없습니다.")
+    private String nickname;
+}

--- a/src/main/java/com/zb/meeteat/domain/user/dto/UpdateNicknameRequest.java
+++ b/src/main/java/com/zb/meeteat/domain/user/dto/UpdateNicknameRequest.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @Getter
 public class UpdateNicknameRequest {
 
-    @NotBlank(message = "닉네임은 비워둘 수 없습니다.")
-    @Pattern(regexp = "^[^\\s]+$", message = "닉네임에는 공백이 포함될 수 없습니다.")
-    private String nickname;
+  @NotBlank(message = "닉네임은 비워둘 수 없습니다.")
+  @Pattern(regexp = "^[^\\s]+$", message = "닉네임에는 공백이 포함될 수 없습니다.")
+  private String nickname;
 }

--- a/src/main/java/com/zb/meeteat/domain/user/dto/UserProfileResponse.java
+++ b/src/main/java/com/zb/meeteat/domain/user/dto/UserProfileResponse.java
@@ -1,0 +1,22 @@
+package com.zb.meeteat.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class UserProfileResponse {
+    private Long id;
+    private String email;
+    private String nickname;
+    private String introduce;
+    private String role;
+    private String signupType;
+    private int matchingCount;
+    private boolean isPenalty;
+    private LocalDateTime bannedAt;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/zb/meeteat/domain/user/dto/UserProfileResponse.java
+++ b/src/main/java/com/zb/meeteat/domain/user/dto/UserProfileResponse.java
@@ -1,22 +1,22 @@
 package com.zb.meeteat.domain.user.dto;
 
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-
-import java.time.LocalDateTime;
 
 @Getter
 @AllArgsConstructor
 public class UserProfileResponse {
-    private Long id;
-    private String email;
-    private String nickname;
-    private String introduce;
-    private String role;
-    private String signupType;
-    private int matchingCount;
-    private boolean isPenalty;
-    private LocalDateTime bannedAt;
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
+
+  private Long id;
+  private String email;
+  private String nickname;
+  private String introduce;
+  private String role;
+  private String signupType;
+  private int matchingCount;
+  private boolean isPenalty;
+  private LocalDateTime bannedAt;
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/zb/meeteat/domain/user/entity/Role.java
+++ b/src/main/java/com/zb/meeteat/domain/user/entity/Role.java
@@ -1,6 +1,6 @@
 package com.zb.meeteat.domain.user.entity;
 
 public enum Role {
-    ADMIN, // 관리자 권한
-    USER   // 일반 사용자 권한
+  ADMIN, // 관리자 권한
+  USER   // 일반 사용자 권한
 }

--- a/src/main/java/com/zb/meeteat/domain/user/entity/SignupType.java
+++ b/src/main/java/com/zb/meeteat/domain/user/entity/SignupType.java
@@ -1,6 +1,6 @@
 package com.zb.meeteat.domain.user.entity;
 
-public enum SignUpType {
+public enum SignupType {
   EMAIL, // 이메일 회원가입
   KAKAO, // 카카오 회원가입
   NAVER  // 네이버 회원가입

--- a/src/main/java/com/zb/meeteat/domain/user/entity/User.java
+++ b/src/main/java/com/zb/meeteat/domain/user/entity/User.java
@@ -14,7 +14,7 @@ import java.util.UUID;
 @AllArgsConstructor
 @Entity
 @Builder
-@Table(name = "user", uniqueConstraints = {
+@Table(name = "`user`", uniqueConstraints = {
         @UniqueConstraint(columnNames = "email"),
         @UniqueConstraint(columnNames = "nickname")
 })
@@ -33,6 +33,7 @@ public class User {
     @Column(nullable = false, unique = false)
     private String nickname;
 
+    @Column(length = 50)
     private String introduce;
 
     @Enumerated(EnumType.STRING)
@@ -118,6 +119,16 @@ public class User {
                 .signupType(SignUpType.NAVER)
                 .role(Role.USER)
                 .build();
+    }
+
+    public void updateNickname(String newNickname) {
+        this.nickname = newNickname;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void updateIntroduce(String newIntroduce) {
+        this.introduce = newIntroduce;
+        this.updatedAt = LocalDateTime.now();
     }
 
 

--- a/src/main/java/com/zb/meeteat/domain/user/entity/User.java
+++ b/src/main/java/com/zb/meeteat/domain/user/entity/User.java
@@ -2,11 +2,24 @@ package com.zb.meeteat.domain.user.entity;
 
 import com.zb.meeteat.external.kakao.KakaoUserResponse;
 import com.zb.meeteat.external.naver.NaverUserResponse;
-import jakarta.persistence.*;
-import lombok.*;
-
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
 import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Setter
@@ -15,121 +28,121 @@ import java.util.UUID;
 @Entity
 @Builder
 @Table(name = "`user`", uniqueConstraints = {
-        @UniqueConstraint(columnNames = "email"),
-        @UniqueConstraint(columnNames = "nickname")
+    @UniqueConstraint(columnNames = "email"),
+    @UniqueConstraint(columnNames = "nickname")
 })
 public class User {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
 
-    @Column(nullable = false, unique = true)
-    private String email;
+  @Column(nullable = false, unique = true)
+  private String email;
 
-    @Column(nullable = false)
-    private String password;
+  @Column(nullable = false)
+  private String password;
 
-    @Column(nullable = false, unique = false)
-    private String nickname;
+  @Column(nullable = false, unique = false)
+  private String nickname;
 
-    @Column(length = 50)
-    private String introduce;
+  @Column(length = 50)
+  private String introduce;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private Role role; // 사용자 권한 (ADMIN / USER)
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private Role role; // 사용자 권한 (ADMIN / USER)
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private SignUpType signupType; // 가입 유형 (EMAIL / KAKAO / NAVER)
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private SignUpType signupType; // 가입 유형 (EMAIL / KAKAO / NAVER)
 
-    @Builder.Default
-    private Integer matchingCount = 0; // 매칭 횟수 (기본값 0)
+  @Builder.Default
+  private Integer matchingCount = 0; // 매칭 횟수 (기본값 0)
 
-    @Builder.Default
-    private Boolean isPenalty = false; // 패널티 여부 (기본값 false)
+  @Builder.Default
+  private Boolean isPenalty = false; // 패널티 여부 (기본값 false)
 
-    private LocalDateTime bannedAt; // 계정 정지 날짜
+  private LocalDateTime bannedAt; // 계정 정지 날짜
 
-    private LocalDateTime bannedEndAt; // 계정 정지 해제 날짜
+  private LocalDateTime bannedEndAt; // 계정 정지 해제 날짜
 
-    @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;
+  @Column(nullable = false, updatable = false)
+  private LocalDateTime createdAt;
 
-    @Column(nullable = false)
-    private LocalDateTime updatedAt;
+  @Column(nullable = false)
+  private LocalDateTime updatedAt;
 
-    @PrePersist
-    protected void onCreate() {
-        this.createdAt = LocalDateTime.now();
-        this.updatedAt = LocalDateTime.now();
+  @PrePersist
+  protected void onCreate() {
+    this.createdAt = LocalDateTime.now();
+    this.updatedAt = LocalDateTime.now();
+  }
+
+  @PreUpdate
+  protected void onUpdate() {
+    this.updatedAt = LocalDateTime.now();
+  }
+
+  public boolean isProfileIncomplete() {
+    return this.nickname == null || this.nickname.isEmpty()
+        || this.introduce == null || this.introduce.isEmpty();
+  }
+
+
+  public static User ofKakao(KakaoUserResponse response) {
+    String email = response.getKakaoAccount().getEmail();
+    String nickname = response.getKakaoAccount().getNickname();
+
+    // 이메일이 없을 경우 임시 이메일 설정
+    if (email == null || email.isEmpty()) {
+      email = "kakao_" + UUID.randomUUID().toString().substring(0, 8) + "@temp.com";
     }
 
-    @PreUpdate
-    protected void onUpdate() {
-        this.updatedAt = LocalDateTime.now();
+    // 닉네임이 없을 경우 기본 닉네임 설정
+    if (nickname == null || nickname.isEmpty()) {
+      nickname = "카카오사용자_" + UUID.randomUUID().toString().substring(0, 6);
     }
 
-    public boolean isProfileIncomplete() {
-        return this.nickname == null || this.nickname.isEmpty()
-                || this.introduce == null || this.introduce.isEmpty();
+    return User.builder()
+        .email(email)
+        .nickname(nickname)
+        .password(UUID.randomUUID().toString())  // 랜덤 더미 비밀번호 설정
+        .signupType(SignUpType.KAKAO)
+        .role(Role.USER)
+        .build();
+  }
+
+  public static User ofNaver(NaverUserResponse response) {
+    String email = response.getResponse().getEmail();
+    String nickname = response.getResponse().getNickname();
+
+    if (email == null || email.isEmpty()) {
+      email = "naver_" + UUID.randomUUID().toString().substring(0, 8) + "@temp.com";
     }
 
-
-    public static User ofKakao(KakaoUserResponse response) {
-        String email = response.getKakaoAccount().getEmail();
-        String nickname = response.getKakaoAccount().getNickname();
-
-        // 이메일이 없을 경우 임시 이메일 설정
-        if (email == null || email.isEmpty()) {
-            email = "kakao_" + UUID.randomUUID().toString().substring(0, 8) + "@temp.com";
-        }
-
-        // 닉네임이 없을 경우 기본 닉네임 설정
-        if (nickname == null || nickname.isEmpty()) {
-            nickname = "카카오사용자_" + UUID.randomUUID().toString().substring(0, 6);
-        }
-
-        return User.builder()
-                .email(email)
-                .nickname(nickname)
-                .password(UUID.randomUUID().toString())  // 랜덤 더미 비밀번호 설정
-                .signupType(SignUpType.KAKAO)
-                .role(Role.USER)
-                .build();
+    if (nickname == null || nickname.isEmpty()) {
+      nickname = "네이버사용자_" + UUID.randomUUID().toString().substring(0, 6);
     }
 
-    public static User ofNaver(NaverUserResponse response) {
-        String email = response.getResponse().getEmail();
-        String nickname = response.getResponse().getNickname();
+    return User.builder()
+        .email(email)
+        .nickname(nickname)
+        .password(UUID.randomUUID().toString())
+        .signupType(SignUpType.NAVER)
+        .role(Role.USER)
+        .build();
+  }
 
-        if (email == null || email.isEmpty()) {
-            email = "naver_" + UUID.randomUUID().toString().substring(0, 8) + "@temp.com";
-        }
+  public void updateNickname(String newNickname) {
+    this.nickname = newNickname;
+    this.updatedAt = LocalDateTime.now();
+  }
 
-        if (nickname == null || nickname.isEmpty()) {
-            nickname = "네이버사용자_" + UUID.randomUUID().toString().substring(0, 6);
-        }
-
-        return User.builder()
-                .email(email)
-                .nickname(nickname)
-                .password(UUID.randomUUID().toString())
-                .signupType(SignUpType.NAVER)
-                .role(Role.USER)
-                .build();
-    }
-
-    public void updateNickname(String newNickname) {
-        this.nickname = newNickname;
-        this.updatedAt = LocalDateTime.now();
-    }
-
-    public void updateIntroduce(String newIntroduce) {
-        this.introduce = newIntroduce;
-        this.updatedAt = LocalDateTime.now();
-    }
+  public void updateIntroduce(String newIntroduce) {
+    this.introduce = newIntroduce;
+    this.updatedAt = LocalDateTime.now();
+  }
 
 
 }

--- a/src/main/java/com/zb/meeteat/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/zb/meeteat/domain/user/repository/UserRepository.java
@@ -1,21 +1,20 @@
 package com.zb.meeteat.domain.user.repository;
 
 import com.zb.meeteat.domain.user.entity.User;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    // 이메일로 사용자 찾기
-    Optional<User> findByEmail(String email);
+  // 이메일로 사용자 찾기
+  Optional<User> findByEmail(String email);
 
-    // 닉네임으로 사용자 찾기
-    Optional<User> findByNickname(String nickname);
+  // 닉네임으로 사용자 찾기
+  Optional<User> findByNickname(String nickname);
 
-    // 이메일 중복 체크
-    boolean existsByEmail(String email);
+  // 이메일 중복 체크
+  boolean existsByEmail(String email);
 
-    // 닉네임 중복 체크
-    boolean existsByNickname(String nickname);
+  // 닉네임 중복 체크
+  boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/zb/meeteat/domain/user/service/AuthService.java
+++ b/src/main/java/com/zb/meeteat/domain/user/service/AuthService.java
@@ -9,10 +9,11 @@ import com.zb.meeteat.domain.user.entity.SignUpType;
 import com.zb.meeteat.domain.user.entity.User;
 import com.zb.meeteat.domain.user.repository.UserRepository;
 import com.zb.meeteat.exception.CustomException;
-import com.zb.meeteat.exception.ErrorCode;
+import com.zb.meeteat.exception.UserErrorCode;
 import com.zb.meeteat.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -56,24 +57,23 @@ public class AuthService {
     public AuthCodeResponseDto signin(SigninRequestDto request) {
         // 1. 이메일로 사용자 찾기
         User user = userRepository.findByEmail(request.getEmail())
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
 
         // 2. 탈퇴 예정 계정인지 확인 (`isPenalty`가 true면 탈퇴 예정 상태)
         if (user.getIsPenalty()) {
-            throw new CustomException(ErrorCode.USER_SCHEDULED_FOR_DELETION);
+            throw new CustomException(UserErrorCode.USER_SCHEDULED_FOR_DELETION);
         }
 
         // 3. 비밀번호 검증
         if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
-            throw new CustomException(ErrorCode.INVALID_CREDENTIALS);
+            throw new CustomException(UserErrorCode.INVALID_CREDENTIALS);
         }
 
         // 4. JWT 토큰 생성
         String accessToken = jwtUtil.generateToken(user);
 
         // 5. 프로필 업데이트 필요 여부 확인 (닉네임이 없거나 비어있는 경우 true)
-        boolean needProfileUpdate = (user.getNickname() == null || user.getNickname().isBlank());
-
+        boolean needProfileUpdate = user.isProfileIncomplete();
         return new AuthCodeResponseDto(accessToken, needProfileUpdate);
     }
 
@@ -82,7 +82,7 @@ public class AuthService {
         String jwt = token.replace("Bearer ", "");
 
         if (!jwtUtil.validateToken(jwt)) {
-            throw new CustomException(ErrorCode.INVALID_TOKEN);
+            throw new CustomException(UserErrorCode.INVALID_TOKEN);
         }
 
         jwtUtil.blacklistToken(jwt);
@@ -92,12 +92,12 @@ public class AuthService {
     public void changePassword(User user, ChangePasswordRequest request) {
         // 1. 현재 비밀번호 검증
         if (!passwordEncoder.matches(request.getCurrentPassword(), user.getPassword())) {
-            throw new CustomException(ErrorCode.PASSWORD_MISMATCH);
+            throw new CustomException(UserErrorCode.PASSWORD_MISMATCH);
         }
 
         // 2. 새 비밀번호가 현재 비밀번호와 동일한지 체크
         if (passwordEncoder.matches(request.getNewPassword(), user.getPassword())) {
-            throw new CustomException(ErrorCode.SAME_PASSWORD);
+            throw new CustomException(UserErrorCode.SAME_PASSWORD);
         }
 
         // 3. 비밀번호 변경 후 저장

--- a/src/main/java/com/zb/meeteat/domain/user/service/AuthService.java
+++ b/src/main/java/com/zb/meeteat/domain/user/service/AuthService.java
@@ -22,87 +22,87 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class AuthService {
 
-    private final UserRepository userRepository;
-    private final PasswordEncoder passwordEncoder;
-    private final JwtUtil jwtUtil;
+  private final UserRepository userRepository;
+  private final PasswordEncoder passwordEncoder;
+  private final JwtUtil jwtUtil;
 
-    @Transactional
-    public User signup(SignupRequestDto requestDto) {
-        validateDuplicateUser(requestDto.getEmail(), requestDto.getNickname());
+  @Transactional
+  public User signup(SignupRequestDto requestDto) {
+    validateDuplicateUser(requestDto.getEmail(), requestDto.getNickname());
 
-        String encodedPassword = passwordEncoder.encode(requestDto.getPassword());
+    String encodedPassword = passwordEncoder.encode(requestDto.getPassword());
 
-        User user = User.builder()
-                .email(requestDto.getEmail())
-                .password(encodedPassword)
-                .nickname(requestDto.getNickname())
-                .role(Role.USER)
-                .signupType(SignUpType.EMAIL)
-                .build();
+    User user = User.builder()
+        .email(requestDto.getEmail())
+        .password(encodedPassword)
+        .nickname(requestDto.getNickname())
+        .role(Role.USER)
+        .signupType(SignUpType.EMAIL)
+        .build();
 
-        return userRepository.save(user);
+    return userRepository.save(user);
+  }
+
+  private void validateDuplicateUser(String email, String nickname) {
+    if (userRepository.existsByEmail(email)) {
+      throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
+    }
+    if (userRepository.existsByNickname(nickname)) {
+      throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
+    }
+  }
+
+  @Transactional
+  public AuthCodeResponseDto signin(SigninRequestDto request) {
+    // 1. 이메일로 사용자 찾기
+    User user = userRepository.findByEmail(request.getEmail())
+        .orElseThrow(() -> new UserCustomException(UserErrorCode.USER_NOT_FOUND));
+
+    // 2. 탈퇴 예정 계정인지 확인 (`isPenalty`가 true면 탈퇴 예정 상태)
+    if (user.getIsPenalty()) {
+      throw new UserCustomException(UserErrorCode.USER_SCHEDULED_FOR_DELETION);
     }
 
-    private void validateDuplicateUser(String email, String nickname) {
-        if (userRepository.existsByEmail(email)) {
-            throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
-        }
-        if (userRepository.existsByNickname(nickname)) {
-            throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
-        }
+    // 3. 비밀번호 검증
+    if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+      throw new UserCustomException(UserErrorCode.INVALID_CREDENTIALS);
     }
 
-    @Transactional
-    public AuthCodeResponseDto signin(SigninRequestDto request) {
-        // 1. 이메일로 사용자 찾기
-        User user = userRepository.findByEmail(request.getEmail())
-                .orElseThrow(() -> new UserCustomException(UserErrorCode.USER_NOT_FOUND));
+    // 4. JWT 토큰 생성
+    String accessToken = jwtUtil.generateToken(user);
 
-        // 2. 탈퇴 예정 계정인지 확인 (`isPenalty`가 true면 탈퇴 예정 상태)
-        if (user.getIsPenalty()) {
-            throw new UserCustomException(UserErrorCode.USER_SCHEDULED_FOR_DELETION);
-        }
+    // 5. 프로필 업데이트 필요 여부 확인 (닉네임이 없거나 비어있는 경우 true)
+    boolean needProfileUpdate = user.isProfileIncomplete();
+    return new AuthCodeResponseDto(accessToken, needProfileUpdate);
+  }
 
-        // 3. 비밀번호 검증
-        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
-            throw new UserCustomException(UserErrorCode.INVALID_CREDENTIALS);
-        }
+  @Transactional
+  public void signout(String token) {
+    String jwt = token.replace("Bearer ", "");
 
-        // 4. JWT 토큰 생성
-        String accessToken = jwtUtil.generateToken(user);
-
-        // 5. 프로필 업데이트 필요 여부 확인 (닉네임이 없거나 비어있는 경우 true)
-        boolean needProfileUpdate = user.isProfileIncomplete();
-        return new AuthCodeResponseDto(accessToken, needProfileUpdate);
+    if (!jwtUtil.validateToken(jwt)) {
+      throw new UserCustomException(UserErrorCode.INVALID_TOKEN);
     }
 
-    @Transactional
-    public void signout(String token) {
-        String jwt = token.replace("Bearer ", "");
+    jwtUtil.blacklistToken(jwt);
+  }
 
-        if (!jwtUtil.validateToken(jwt)) {
-            throw new UserCustomException(UserErrorCode.INVALID_TOKEN);
-        }
-
-        jwtUtil.blacklistToken(jwt);
+  @Transactional
+  public void changePassword(User user, ChangePasswordRequest request) {
+    // 1. 현재 비밀번호 검증
+    if (!passwordEncoder.matches(request.getCurrentPassword(), user.getPassword())) {
+      throw new UserCustomException(UserErrorCode.PASSWORD_MISMATCH);
     }
 
-    @Transactional
-    public void changePassword(User user, ChangePasswordRequest request) {
-        // 1. 현재 비밀번호 검증
-        if (!passwordEncoder.matches(request.getCurrentPassword(), user.getPassword())) {
-            throw new UserCustomException(UserErrorCode.PASSWORD_MISMATCH);
-        }
-
-        // 2. 새 비밀번호가 현재 비밀번호와 동일한지 체크
-        if (passwordEncoder.matches(request.getNewPassword(), user.getPassword())) {
-            throw new UserCustomException(UserErrorCode.SAME_PASSWORD);
-        }
-
-        // 3. 비밀번호 변경 후 저장
-        user.setPassword(passwordEncoder.encode(request.getNewPassword()));
-        userRepository.save(user);
+    // 2. 새 비밀번호가 현재 비밀번호와 동일한지 체크
+    if (passwordEncoder.matches(request.getNewPassword(), user.getPassword())) {
+      throw new UserCustomException(UserErrorCode.SAME_PASSWORD);
     }
+
+    // 3. 비밀번호 변경 후 저장
+    user.setPassword(passwordEncoder.encode(request.getNewPassword()));
+    userRepository.save(user);
+  }
 
 }
 

--- a/src/main/java/com/zb/meeteat/domain/user/service/SocialAuthService.java
+++ b/src/main/java/com/zb/meeteat/domain/user/service/SocialAuthService.java
@@ -20,108 +20,107 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class SocialAuthService {
 
-    private final UserRepository userRepository;
-    private final JwtUtil jwtUtil;
-    private final KakaoAuthClient kakaoAuthClient;
-    private final NaverAuthClient naverAuthClient;
+  private final UserRepository userRepository;
+  private final JwtUtil jwtUtil;
+  private final KakaoAuthClient kakaoAuthClient;
+  private final NaverAuthClient naverAuthClient;
 
-    @Transactional
-    public AuthCodeResponseDto socialSignin(String provider, String authCode) {
-        if ("kakao".equalsIgnoreCase(provider)) {
-            return processKakaoSignin(authCode);
-        } else if ("naver".equalsIgnoreCase(provider)) {
-            return processNaverSignin(authCode);
-        } else {
-            throw new IllegalArgumentException("지원하지 않는 소셜 로그인입니다.");
-        }
+  @Transactional
+  public AuthCodeResponseDto socialSignin(String provider, String authCode) {
+    if ("kakao".equalsIgnoreCase(provider)) {
+      return processKakaoSignin(authCode);
+    } else if ("naver".equalsIgnoreCase(provider)) {
+      return processNaverSignin(authCode);
+    } else {
+      throw new IllegalArgumentException("지원하지 않는 소셜 로그인입니다.");
+    }
+  }
+
+
+  public AuthCodeResponseDto processKakaoSignin(String authCode) {
+
+    try {
+      log.info("받은 authCode: {}", authCode);
+
+      // 카카오에서 토큰 가져오기
+      KakaoTokenResponse tokenResponse = kakaoAuthClient.getToken(authCode);
+      if (tokenResponse == null || tokenResponse.getAccessToken() == null) {
+        throw new IllegalArgumentException("카카오 액세스 토큰을 가져올 수 없습니다.");
+      }
+      log.info("받은 카카오 액세스 토큰: {}", tokenResponse.getAccessToken());
+
+      // 토큰을 이용해 사용자 정보 가져오기
+      KakaoUserResponse userResponse = kakaoAuthClient.getUserInfo(tokenResponse.getAccessToken());
+      if (userResponse == null || userResponse.getKakaoAccount() == null) {
+        throw new IllegalArgumentException("카카오 사용자 정보를 가져올 수 없습니다.");
+      }
+      log.info("받은 카카오 사용자 정보: {}", userResponse);
+
+      // 이메일 기준으로 사용자 확인 (기존 회원 목록에 없으면 새로 생성)
+      String email = userResponse.getKakaoAccount().getEmail();
+      if (email == null) {
+        throw new IllegalArgumentException("카카오 사용자 이메일 정보가 없습니다.");
+      }
+
+      User user = userRepository.findByEmail(email)
+          .orElseGet(() -> {
+            log.info("신규 카카오 사용자 저장: {}", email);
+            return userRepository.save(User.ofKakao(userResponse));
+          });
+
+      // JWT 발급
+      String jwtToken = jwtUtil.generateToken(user);
+      log.info("JWT 토큰 발급: {}", jwtToken);
+
+      // 응답 DTO 반환
+      return new AuthCodeResponseDto(jwtToken, user.isProfileIncomplete());
+
+    } catch (Exception e) {
+      log.error("카카오 로그인 중 오류 발생: {}", e.getMessage(), e);
+      throw new RuntimeException("카카오 로그인 중 오류 발생: " + e.getMessage());
+    }
+  }
+
+  private AuthCodeResponseDto processNaverSignin(String authCode) {
+    try {
+      log.info("받은 네이버 authCode: {}", authCode);
+
+      // 네이버에서 토큰 가져오기
+      NaverTokenResponse tokenResponse = naverAuthClient.getToken(authCode);
+      if (tokenResponse == null || tokenResponse.getAccessToken() == null) {
+        throw new IllegalArgumentException("네이버 액세스 토큰을 가져올 수 없습니다.");
+      }
+      log.info("받은 네이버 액세스 토큰: {}", tokenResponse.getAccessToken());
+
+      // 토큰을 이용해 사용자 정보 가져오기
+      NaverUserResponse userResponse = naverAuthClient.getUserInfo(tokenResponse.getAccessToken());
+      if (userResponse == null || userResponse.getResponse() == null) {
+        throw new IllegalArgumentException("네이버 사용자 정보를 가져올 수 없습니다.");
+      }
+      log.info("받은 네이버 사용자 정보: {}", userResponse);
+
+      // 이메일 기준으로 사용자 확인 (기존 회원 목록에 없으면 새로 생성)
+      String email = userResponse.getResponse().getEmail();
+      if (email == null) {
+        throw new IllegalArgumentException("네이버 사용자 이메일 정보가 없습니다.");
+      }
+
+      User user = userRepository.findByEmail(email)
+          .orElseGet(() -> {
+            log.info("신규 네이버 사용자 저장: {}", email);
+            return userRepository.save(User.ofNaver(userResponse));
+          });
+
+      // JWT 발급
+      String jwtToken = jwtUtil.generateToken(user);
+      log.info("JWT 토큰 발급: {}", jwtToken);
+
+      // 응답 DTO 반환
+      return new AuthCodeResponseDto(jwtToken, user.isProfileIncomplete());
+    } catch (Exception e) {
+      log.error("네이버 로그인 중 오류 발생: {}", e.getMessage(), e);
+      throw new RuntimeException("네이버 로그인 중 오류 발생: " + e.getMessage());
     }
 
-
-    public AuthCodeResponseDto processKakaoSignin(String authCode) {
-
-        try {
-            log.info("받은 authCode: {}", authCode);
-
-            // 카카오에서 토큰 가져오기
-            KakaoTokenResponse tokenResponse = kakaoAuthClient.getToken(authCode);
-            if (tokenResponse == null || tokenResponse.getAccessToken() == null) {
-                throw new IllegalArgumentException("카카오 액세스 토큰을 가져올 수 없습니다.");
-            }
-            log.info("받은 카카오 액세스 토큰: {}", tokenResponse.getAccessToken());
-
-            // 토큰을 이용해 사용자 정보 가져오기
-            KakaoUserResponse userResponse = kakaoAuthClient.getUserInfo(tokenResponse.getAccessToken());
-            if (userResponse == null || userResponse.getKakaoAccount() == null) {
-                throw new IllegalArgumentException("카카오 사용자 정보를 가져올 수 없습니다.");
-            }
-            log.info("받은 카카오 사용자 정보: {}", userResponse);
-
-            // 이메일 기준으로 사용자 확인 (기존 회원 목록에 없으면 새로 생성)
-            String email = userResponse.getKakaoAccount().getEmail();
-            if (email == null) {
-                throw new IllegalArgumentException("카카오 사용자 이메일 정보가 없습니다.");
-            }
-
-            User user = userRepository.findByEmail(email)
-                    .orElseGet(() -> {
-                        log.info("신규 카카오 사용자 저장: {}", email);
-                        return userRepository.save(User.ofKakao(userResponse));
-                    });
-
-
-            // JWT 발급
-            String jwtToken = jwtUtil.generateToken(user);
-            log.info("JWT 토큰 발급: {}", jwtToken);
-
-            // 응답 DTO 반환
-            return new AuthCodeResponseDto(jwtToken, user.isProfileIncomplete());
-
-        } catch (Exception e) {
-            log.error("카카오 로그인 중 오류 발생: {}", e.getMessage(), e);
-            throw new RuntimeException("카카오 로그인 중 오류 발생: " + e.getMessage());
-        }
-    }
-
-    private AuthCodeResponseDto processNaverSignin(String authCode) {
-        try {
-            log.info("받은 네이버 authCode: {}", authCode);
-
-            // 네이버에서 토큰 가져오기
-            NaverTokenResponse tokenResponse = naverAuthClient.getToken(authCode);
-            if (tokenResponse == null || tokenResponse.getAccessToken() == null) {
-                throw new IllegalArgumentException("네이버 액세스 토큰을 가져올 수 없습니다.");
-            }
-            log.info("받은 네이버 액세스 토큰: {}", tokenResponse.getAccessToken());
-
-            // 토큰을 이용해 사용자 정보 가져오기
-            NaverUserResponse userResponse = naverAuthClient.getUserInfo(tokenResponse.getAccessToken());
-            if (userResponse == null || userResponse.getResponse() == null) {
-                throw new IllegalArgumentException("네이버 사용자 정보를 가져올 수 없습니다.");
-            }
-            log.info("받은 네이버 사용자 정보: {}", userResponse);
-
-            // 이메일 기준으로 사용자 확인 (기존 회원 목록에 없으면 새로 생성)
-            String email = userResponse.getResponse().getEmail();
-            if (email == null) {
-                throw new IllegalArgumentException("네이버 사용자 이메일 정보가 없습니다.");
-            }
-
-            User user = userRepository.findByEmail(email)
-                    .orElseGet(() -> {
-                        log.info("신규 네이버 사용자 저장: {}", email);
-                        return userRepository.save(User.ofNaver(userResponse));
-                    });
-
-            // JWT 발급
-            String jwtToken = jwtUtil.generateToken(user);
-            log.info("JWT 토큰 발급: {}", jwtToken);
-
-            // 응답 DTO 반환
-            return new AuthCodeResponseDto(jwtToken, user.isProfileIncomplete());
-        } catch (Exception e) {
-            log.error("네이버 로그인 중 오류 발생: {}", e.getMessage(), e);
-            throw new RuntimeException("네이버 로그인 중 오류 발생: " + e.getMessage());
-        }
-
-    }
+  }
 }

--- a/src/main/java/com/zb/meeteat/domain/user/service/UserService.java
+++ b/src/main/java/com/zb/meeteat/domain/user/service/UserService.java
@@ -1,0 +1,59 @@
+package com.zb.meeteat.domain.user.service;
+
+import com.zb.meeteat.domain.user.dto.UserProfileResponse;
+import com.zb.meeteat.domain.user.entity.User;
+import com.zb.meeteat.domain.user.repository.UserRepository;
+import com.zb.meeteat.exception.CustomException;
+import com.zb.meeteat.exception.UserErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public UserProfileResponse getUserProfile(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+
+        return new UserProfileResponse(
+                user.getId(),
+                user.getEmail(),
+                user.getNickname(),
+                user.getIntroduce(),
+                user.getRole().name(),
+                user.getSignupType().name(),
+                user.getMatchingCount(),
+                user.getIsPenalty(),
+                user.getBannedAt(),
+                user.getCreatedAt(),
+                user.getUpdatedAt()
+        );
+    }
+
+    @Transactional
+    public void updateNickname(User user, String newNickname) {
+        // 닉네임 중복 검사
+        if (userRepository.existsByNickname(newNickname)) {
+            throw new CustomException(UserErrorCode.NICKNAME_ALREADY_REGISTERED);
+        }
+
+        // 닉네임 변경
+        user.updateNickname(newNickname);
+        userRepository.save(user);
+    }
+
+    @Transactional
+    public void updateIntroduce(User user, String newIntroduce) {
+        user.updateIntroduce(newIntroduce);
+        userRepository.save(user);
+    }
+
+
+
+}
+

--- a/src/main/java/com/zb/meeteat/domain/user/service/UserService.java
+++ b/src/main/java/com/zb/meeteat/domain/user/service/UserService.java
@@ -13,46 +13,45 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class UserService {
 
-    private final UserRepository userRepository;
+  private final UserRepository userRepository;
 
-    @Transactional
-    public UserProfileResponse getUserProfile(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserCustomException(UserErrorCode.USER_NOT_FOUND));
+  @Transactional
+  public UserProfileResponse getUserProfile(Long userId) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new UserCustomException(UserErrorCode.USER_NOT_FOUND));
 
-        return new UserProfileResponse(
-                user.getId(),
-                user.getEmail(),
-                user.getNickname(),
-                user.getIntroduce(),
-                user.getRole().name(),
-                user.getSignupType().name(),
-                user.getMatchingCount(),
-                user.getIsPenalty(),
-                user.getBannedAt(),
-                user.getCreatedAt(),
-                user.getUpdatedAt()
-        );
+    return new UserProfileResponse(
+        user.getId(),
+        user.getEmail(),
+        user.getNickname(),
+        user.getIntroduce(),
+        user.getRole().name(),
+        user.getSignupType().name(),
+        user.getMatchingCount(),
+        user.getIsPenalty(),
+        user.getBannedAt(),
+        user.getCreatedAt(),
+        user.getUpdatedAt()
+    );
+  }
+
+  @Transactional
+  public void updateNickname(User user, String newNickname) {
+    // 닉네임 중복 검사
+    if (userRepository.existsByNickname(newNickname)) {
+      throw new UserCustomException(UserErrorCode.NICKNAME_ALREADY_REGISTERED);
     }
 
-    @Transactional
-    public void updateNickname(User user, String newNickname) {
-        // 닉네임 중복 검사
-        if (userRepository.existsByNickname(newNickname)) {
-            throw new UserCustomException(UserErrorCode.NICKNAME_ALREADY_REGISTERED);
-        }
+    // 닉네임 변경
+    user.updateNickname(newNickname);
+    userRepository.save(user);
+  }
 
-        // 닉네임 변경
-        user.updateNickname(newNickname);
-        userRepository.save(user);
-    }
-
-    @Transactional
-    public void updateIntroduce(User user, String newIntroduce) {
-        user.updateIntroduce(newIntroduce);
-        userRepository.save(user);
-    }
-
+  @Transactional
+  public void updateIntroduce(User user, String newIntroduce) {
+    user.updateIntroduce(newIntroduce);
+    userRepository.save(user);
+  }
 
 
 }

--- a/src/main/java/com/zb/meeteat/exception/ApiControllerAdvice.java
+++ b/src/main/java/com/zb/meeteat/exception/ApiControllerAdvice.java
@@ -45,6 +45,7 @@ public class ApiControllerAdvice {
   @Getter
   @AllArgsConstructor
   public static class ExceptionResponse {
+
     private int status;
     private String message;
   }

--- a/src/main/java/com/zb/meeteat/exception/CustomException.java
+++ b/src/main/java/com/zb/meeteat/exception/CustomException.java
@@ -4,10 +4,11 @@ import lombok.Getter;
 
 @Getter
 public class CustomException extends RuntimeException {
-    private final ErrorCode errorCode;
 
-    public CustomException(ErrorCode errorCode) {
-        super(errorCode.getMessage());
-        this.errorCode = errorCode;
-    }
+  private final ErrorCode errorCode;
+
+  public CustomException(ErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
+  }
 }

--- a/src/main/java/com/zb/meeteat/exception/CustomException.java
+++ b/src/main/java/com/zb/meeteat/exception/CustomException.java
@@ -4,10 +4,10 @@ import lombok.Getter;
 
 @Getter
 public class CustomException extends RuntimeException {
-    private final ErrorCode errorCode;
+    private final UserErrorCode userErrorCode;
 
-    public CustomException(ErrorCode errorCode) {
-        super(errorCode.getMessage());
-        this.errorCode = errorCode;
+    public CustomException(UserErrorCode userErrorCode) {
+        super(userErrorCode.getMessage());
+        this.userErrorCode = userErrorCode;
     }
 }

--- a/src/main/java/com/zb/meeteat/exception/ErrorCode.java
+++ b/src/main/java/com/zb/meeteat/exception/ErrorCode.java
@@ -13,7 +13,11 @@ public enum ErrorCode {
     NICKNAME_ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "NICKNAME_ALREADY_REGISTERED", "이미 사용 중인 닉네임입니다."),
     USER_SCHEDULED_FOR_DELETION(HttpStatus.FORBIDDEN, "USER_SCHEDULED_FOR_DELETION", "해당 계정은 탈퇴 예정 상태입니다."),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "BAD_REQUEST", "잘못된 요청입니다."),
-    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "INVALID_TOKEN", "유효하지 않은 토큰입니다.");
+    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "INVALID_TOKEN", "유효하지 않은 토큰입니다."),
+    PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "PASSWORD_MISMATCH", "현재 비밀번호가 일치하지 않습니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "INVALID_PASSWORD", "비밀번호는 최소 8자 이상이며, 영문, 숫자, 특수문자를 각각 하나 이상 포함해야 합니다."),
+    SAME_PASSWORD(HttpStatus.BAD_REQUEST, "SAME_PASSWORD", "현재 비밀번호와 동일한 비밀번호로 변경할 수 없습니다.");
+
 
 
     private final HttpStatus status;

--- a/src/main/java/com/zb/meeteat/exception/ErrorCode.java
+++ b/src/main/java/com/zb/meeteat/exception/ErrorCode.java
@@ -7,24 +7,28 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
-    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다."),
-    INVALID_CREDENTIALS(HttpStatus.BAD_REQUEST, "INVALID_CREDENTIALS", "이메일 또는 비밀번호가 잘못되었습니다."),
-    EMAIL_ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "EMAIL_ALREADY_REGISTERED", "이미 사용 중인 이메일입니다."),
-    NICKNAME_ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "NICKNAME_ALREADY_REGISTERED", "이미 사용 중인 닉네임입니다."),
-    USER_SCHEDULED_FOR_DELETION(HttpStatus.FORBIDDEN, "USER_SCHEDULED_FOR_DELETION", "해당 계정은 탈퇴 예정 상태입니다.")
-    ,REVIEW_NOT_ALLOWED_FOR_CANCELED_MATCHING(HttpStatus.BAD_REQUEST,"REVIEW_NOT_ALLOWED_FOR_CANCELED_MATCHING", "취소된 매칭으로는 후기를 작성할 수 없습니다.")
-    ,REVIEW_TIME_NOT_EXCEEDED(HttpStatus.BAD_REQUEST,"REVIEW_TIME_NOT_EXCEEDED", "후기 작성시간은 매칭 약속 시간 이후 2시간 이후부터 작성가능합니다.")
-    ,CANCELED_MATCHING(HttpStatus.BAD_REQUEST,"CANCELED_MATCHING", "취소된 매칭입니다.")
-    ,NOT_EXIST_RESTAURANT(HttpStatus.BAD_REQUEST,"NOT_EXIST_RESTAURANT", "삭제되었거나 존재하지 않는 식당입니다.")
-    ,FAIL_FILE_UPLOAD(HttpStatus.INTERNAL_SERVER_ERROR,"FAIL_FILE_UPLOAD", "이미지 업로드에 실패하였습니다.")
-    ,FILE_UPLOAD_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST,"FILE_UPLOAD_LIMIT_EXCEEDED", "업로드 파일 최대 갯수는 5장입니다.")
-    ,INVALID_FILE_FORMAT(HttpStatus.BAD_REQUEST,"INVALID_FILE_FORMAT", "잘못된 이미지 형식입니다. jpg, jpeg, png 만 허용됩니다.")
-    ,USER_LOCATION_NOT_PROVIDED(HttpStatus.BAD_REQUEST,"USER_LOCATION_NOT_PROVIDED", "거리순 정렬에 사용할 사용자의 위치값이 누락되었습니다.")
-    ,BAD_REQUEST(HttpStatus.BAD_REQUEST, "BAD_REQUEST", "잘못된 요청입니다.")
-    ,INVALID_TOKEN(HttpStatus.BAD_REQUEST, "INVALID_TOKEN", "유효하지 않은 토큰입니다.")
-    ;
+  USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다."),
+  INVALID_CREDENTIALS(HttpStatus.BAD_REQUEST, "INVALID_CREDENTIALS", "이메일 또는 비밀번호가 잘못되었습니다."),
+  EMAIL_ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "EMAIL_ALREADY_REGISTERED", "이미 사용 중인 이메일입니다."),
+  NICKNAME_ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "NICKNAME_ALREADY_REGISTERED",
+      "이미 사용 중인 닉네임입니다."),
+  USER_SCHEDULED_FOR_DELETION(HttpStatus.FORBIDDEN, "USER_SCHEDULED_FOR_DELETION",
+      "해당 계정은 탈퇴 예정 상태입니다."), REVIEW_NOT_ALLOWED_FOR_CANCELED_MATCHING(HttpStatus.BAD_REQUEST,
+      "REVIEW_NOT_ALLOWED_FOR_CANCELED_MATCHING",
+      "취소된 매칭으로는 후기를 작성할 수 없습니다."), REVIEW_TIME_NOT_EXCEEDED(HttpStatus.BAD_REQUEST,
+      "REVIEW_TIME_NOT_EXCEEDED", "후기 작성시간은 매칭 약속 시간 이후 2시간 이후부터 작성가능합니다."), CANCELED_MATCHING(
+      HttpStatus.BAD_REQUEST, "CANCELED_MATCHING", "취소된 매칭입니다."), NOT_EXIST_RESTAURANT(
+      HttpStatus.BAD_REQUEST, "NOT_EXIST_RESTAURANT", "삭제되었거나 존재하지 않는 식당입니다."), FAIL_FILE_UPLOAD(
+      HttpStatus.INTERNAL_SERVER_ERROR, "FAIL_FILE_UPLOAD",
+      "이미지 업로드에 실패하였습니다."), FILE_UPLOAD_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST,
+      "FILE_UPLOAD_LIMIT_EXCEEDED", "업로드 파일 최대 갯수는 5장입니다."), INVALID_FILE_FORMAT(
+      HttpStatus.BAD_REQUEST, "INVALID_FILE_FORMAT",
+      "잘못된 이미지 형식입니다. jpg, jpeg, png 만 허용됩니다."), USER_LOCATION_NOT_PROVIDED(HttpStatus.BAD_REQUEST,
+      "USER_LOCATION_NOT_PROVIDED", "거리순 정렬에 사용할 사용자의 위치값이 누락되었습니다."), BAD_REQUEST(
+      HttpStatus.BAD_REQUEST, "BAD_REQUEST", "잘못된 요청입니다."), INVALID_TOKEN(HttpStatus.BAD_REQUEST,
+      "INVALID_TOKEN", "유효하지 않은 토큰입니다.");
 
-    private final HttpStatus status;
-    private final String code;
-    private final String message;
+  private final HttpStatus status;
+  private final String code;
+  private final String message;
 }

--- a/src/main/java/com/zb/meeteat/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/zb/meeteat/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.zb.meeteat.exception;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import java.util.HashMap;
 import java.util.Map;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
     // IllegalArgumentException이 발생하면 400 응답을 반환 (예: 이메일 중복, 닉네임 중복)
@@ -35,6 +37,7 @@ public class GlobalExceptionHandler {
     // 예상치 못한 예외 발생 시 500 응답을 반환
     @ExceptionHandler(Exception.class)
     public ResponseEntity<String> handleGeneralException(Exception e) {
+        log.error("서버 오류 발생: {}", e.getMessage(), e);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body("서버에 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
     }
@@ -50,7 +53,6 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity.status(errorCode.getStatus()).body(errorResponse);
     }
-
 
 
 }

--- a/src/main/java/com/zb/meeteat/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/zb/meeteat/exception/GlobalExceptionHandler.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import java.util.HashMap;
 import java.util.Map;
 
+
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {

--- a/src/main/java/com/zb/meeteat/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/zb/meeteat/exception/GlobalExceptionHandler.java
@@ -44,14 +44,14 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<Map<String, Object>> handleCustomException(CustomException ex) {
-        ErrorCode errorCode = ex.getErrorCode();
+        UserErrorCode userErrorCode = ex.getUserErrorCode();
 
         Map<String, Object> errorResponse = new HashMap<>();
-        errorResponse.put("status", errorCode.getStatus().value());
-        errorResponse.put("error", errorCode.getCode());
-        errorResponse.put("message", errorCode.getMessage());
+        errorResponse.put("status", userErrorCode.getStatus().value());
+        errorResponse.put("error", userErrorCode.getCode());
+        errorResponse.put("message", userErrorCode.getMessage());
 
-        return ResponseEntity.status(errorCode.getStatus()).body(errorResponse);
+        return ResponseEntity.status(userErrorCode.getStatus()).body(errorResponse);
     }
 
 

--- a/src/main/java/com/zb/meeteat/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/zb/meeteat/exception/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.zb.meeteat.exception;
 
+import java.util.HashMap;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -9,51 +11,49 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import java.util.HashMap;
-import java.util.Map;
-
 
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-    // IllegalArgumentException이 발생하면 400 응답을 반환 (예: 이메일 중복, 닉네임 중복)
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<String> handleIllegalArgumentException(IllegalArgumentException e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+
+  // IllegalArgumentException이 발생하면 400 응답을 반환 (예: 이메일 중복, 닉네임 중복)
+  @ExceptionHandler(IllegalArgumentException.class)
+  public ResponseEntity<String> handleIllegalArgumentException(IllegalArgumentException e) {
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+  }
+
+  // `@Valid` 유효성 검사 실패 (비밀번호 형식 오류 등)
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<String> handleValidationException(MethodArgumentNotValidException e) {
+    BindingResult bindingResult = e.getBindingResult();
+    StringBuilder errorMessage = new StringBuilder();
+
+    for (FieldError fieldError : bindingResult.getFieldErrors()) {
+      errorMessage.append(fieldError.getDefaultMessage()).append(" ");
     }
 
-    // `@Valid` 유효성 검사 실패 (비밀번호 형식 오류 등)
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<String> handleValidationException(MethodArgumentNotValidException e) {
-        BindingResult bindingResult = e.getBindingResult();
-        StringBuilder errorMessage = new StringBuilder();
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorMessage.toString().trim());
+  }
 
-        for (FieldError fieldError : bindingResult.getFieldErrors()) {
-            errorMessage.append(fieldError.getDefaultMessage()).append(" ");
-        }
+  // 예상치 못한 예외 발생 시 500 응답을 반환
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<String> handleGeneralException(Exception e) {
+    log.error("서버 오류 발생: {}", e.getMessage(), e);
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+        .body("서버에 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
+  }
 
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorMessage.toString().trim());
-    }
+  @ExceptionHandler(UserCustomException.class)
+  public ResponseEntity<Map<String, Object>> handleCustomException(UserCustomException ex) {
+    UserErrorCode userErrorCode = ex.getUserErrorCode();
 
-    // 예상치 못한 예외 발생 시 500 응답을 반환
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<String> handleGeneralException(Exception e) {
-        log.error("서버 오류 발생: {}", e.getMessage(), e);
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body("서버에 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
-    }
+    Map<String, Object> errorResponse = new HashMap<>();
+    errorResponse.put("status", userErrorCode.getStatus().value());
+    errorResponse.put("error", userErrorCode.getCode());
+    errorResponse.put("message", userErrorCode.getMessage());
 
-    @ExceptionHandler(UserCustomException.class)
-    public ResponseEntity<Map<String, Object>> handleCustomException(UserCustomException ex) {
-        UserErrorCode userErrorCode = ex.getUserErrorCode();
-
-        Map<String, Object> errorResponse = new HashMap<>();
-        errorResponse.put("status", userErrorCode.getStatus().value());
-        errorResponse.put("error", userErrorCode.getCode());
-        errorResponse.put("message", userErrorCode.getMessage());
-
-        return ResponseEntity.status(userErrorCode.getStatus()).body(errorResponse);
-    }
+    return ResponseEntity.status(userErrorCode.getStatus()).body(errorResponse);
+  }
 
 
 }

--- a/src/main/java/com/zb/meeteat/exception/UserCustomException.java
+++ b/src/main/java/com/zb/meeteat/exception/UserCustomException.java
@@ -4,10 +4,11 @@ import lombok.Getter;
 
 @Getter
 public class UserCustomException extends RuntimeException {
-    private final UserErrorCode userErrorCode;
 
-    public UserCustomException(UserErrorCode userErrorCode) {
-        super(userErrorCode.getMessage());
-        this.userErrorCode = userErrorCode;
-    }
+  private final UserErrorCode userErrorCode;
+
+  public UserCustomException(UserErrorCode userErrorCode) {
+    super(userErrorCode.getMessage());
+    this.userErrorCode = userErrorCode;
+  }
 }

--- a/src/main/java/com/zb/meeteat/exception/UserErrorCode.java
+++ b/src/main/java/com/zb/meeteat/exception/UserErrorCode.java
@@ -7,21 +7,24 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum UserErrorCode {
-    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다."),
-    INVALID_CREDENTIALS(HttpStatus.BAD_REQUEST, "INVALID_CREDENTIALS", "이메일 또는 비밀번호가 잘못되었습니다."),
-    EMAIL_ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "EMAIL_ALREADY_REGISTERED", "이미 사용 중인 이메일입니다."),
-    NICKNAME_ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "NICKNAME_ALREADY_REGISTERED", "이미 사용 중인 닉네임입니다."),
-    USER_SCHEDULED_FOR_DELETION(HttpStatus.FORBIDDEN, "USER_SCHEDULED_FOR_DELETION", "해당 계정은 탈퇴 예정 상태입니다."),
-    BAD_REQUEST(HttpStatus.BAD_REQUEST, "BAD_REQUEST", "잘못된 요청입니다."),
-    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "INVALID_TOKEN", "유효하지 않은 토큰입니다."),
-    PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "PASSWORD_MISMATCH", "현재 비밀번호가 일치하지 않습니다."),
-    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "INVALID_PASSWORD", "비밀번호는 최소 8자 이상이며, 영문, 숫자, 특수문자를 각각 하나 이상 포함해야 합니다."),
-    SAME_PASSWORD(HttpStatus.BAD_REQUEST, "SAME_PASSWORD", "현재 비밀번호와 동일한 비밀번호로 변경할 수 없습니다."),
-    USER_CANNOT_BE_DELETED_DUE_TO_MATCHING(HttpStatus.BAD_REQUEST, "USER_CANNOT_BE_DELETED_DUE_TO_MATCHING", " 현재 매칭 진행 중이므로 탈퇴할 수 없습니다.");
+  USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다."),
+  INVALID_CREDENTIALS(HttpStatus.BAD_REQUEST, "INVALID_CREDENTIALS", "이메일 또는 비밀번호가 잘못되었습니다."),
+  EMAIL_ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "EMAIL_ALREADY_REGISTERED", "이미 사용 중인 이메일입니다."),
+  NICKNAME_ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "NICKNAME_ALREADY_REGISTERED",
+      "이미 사용 중인 닉네임입니다."),
+  USER_SCHEDULED_FOR_DELETION(HttpStatus.FORBIDDEN, "USER_SCHEDULED_FOR_DELETION",
+      "해당 계정은 탈퇴 예정 상태입니다."),
+  BAD_REQUEST(HttpStatus.BAD_REQUEST, "BAD_REQUEST", "잘못된 요청입니다."),
+  INVALID_TOKEN(HttpStatus.BAD_REQUEST, "INVALID_TOKEN", "유효하지 않은 토큰입니다."),
+  PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "PASSWORD_MISMATCH", "현재 비밀번호가 일치하지 않습니다."),
+  INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "INVALID_PASSWORD",
+      "비밀번호는 최소 8자 이상이며, 영문, 숫자, 특수문자를 각각 하나 이상 포함해야 합니다."),
+  SAME_PASSWORD(HttpStatus.BAD_REQUEST, "SAME_PASSWORD", "현재 비밀번호와 동일한 비밀번호로 변경할 수 없습니다."),
+  USER_CANNOT_BE_DELETED_DUE_TO_MATCHING(HttpStatus.BAD_REQUEST,
+      "USER_CANNOT_BE_DELETED_DUE_TO_MATCHING", " 현재 매칭 진행 중이므로 탈퇴할 수 없습니다.");
 
 
-
-    private final HttpStatus status;
-    private final String code;
-    private final String message;
+  private final HttpStatus status;
+  private final String code;
+  private final String message;
 }

--- a/src/main/java/com/zb/meeteat/exception/UserErrorCode.java
+++ b/src/main/java/com/zb/meeteat/exception/UserErrorCode.java
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
-public enum ErrorCode {
+public enum UserErrorCode {
     USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다."),
     INVALID_CREDENTIALS(HttpStatus.BAD_REQUEST, "INVALID_CREDENTIALS", "이메일 또는 비밀번호가 잘못되었습니다."),
     EMAIL_ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "EMAIL_ALREADY_REGISTERED", "이미 사용 중인 이메일입니다."),
@@ -16,7 +16,8 @@ public enum ErrorCode {
     INVALID_TOKEN(HttpStatus.BAD_REQUEST, "INVALID_TOKEN", "유효하지 않은 토큰입니다."),
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "PASSWORD_MISMATCH", "현재 비밀번호가 일치하지 않습니다."),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "INVALID_PASSWORD", "비밀번호는 최소 8자 이상이며, 영문, 숫자, 특수문자를 각각 하나 이상 포함해야 합니다."),
-    SAME_PASSWORD(HttpStatus.BAD_REQUEST, "SAME_PASSWORD", "현재 비밀번호와 동일한 비밀번호로 변경할 수 없습니다.");
+    SAME_PASSWORD(HttpStatus.BAD_REQUEST, "SAME_PASSWORD", "현재 비밀번호와 동일한 비밀번호로 변경할 수 없습니다."),
+    USER_CANNOT_BE_DELETED_DUE_TO_MATCHING(HttpStatus.BAD_REQUEST, "USER_CANNOT_BE_DELETED_DUE_TO_MATCHING", " 현재 매칭 진행 중이므로 탈퇴할 수 없습니다.");
 
 
 

--- a/src/main/java/com/zb/meeteat/external/kakao/KakaoAuthClient.java
+++ b/src/main/java/com/zb/meeteat/external/kakao/KakaoAuthClient.java
@@ -1,66 +1,69 @@
 package com.zb.meeteat.external.kakao;
 
+import java.util.Collections;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.*;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.Collections;
-
 @Component
 @RequiredArgsConstructor
 public class KakaoAuthClient {
 
-    @Value("${kakao.auth.token-url}")
-    private String tokenUrl;
+  @Value("${kakao.auth.token-url}")
+  private String tokenUrl;
 
-    @Value("${kakao.auth.user-info-url}")
-    private String userInfoUrl;
+  @Value("${kakao.auth.user-info-url}")
+  private String userInfoUrl;
 
-    @Value("${kakao.auth.client-id}")
-    private String clientId;
+  @Value("${kakao.auth.client-id}")
+  private String clientId;
 
-    @Value("${kakao.auth.redirect-uri}")
-    private String redirectUri;
+  @Value("${kakao.auth.redirect-uri}")
+  private String redirectUri;
 
-    private final RestTemplate restTemplate = new RestTemplate();
+  private final RestTemplate restTemplate = new RestTemplate();
 
-    public KakaoTokenResponse getToken(String authCode) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-        headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON)); // 응답은 JSON으로 받음
+  public KakaoTokenResponse getToken(String authCode) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+    headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON)); // 응답은 JSON으로 받음
 
-        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        params.add("grant_type", "authorization_code");
-        params.add("client_id", clientId);
-        params.add("redirect_uri", redirectUri);
-        params.add("code", authCode);
+    MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+    params.add("grant_type", "authorization_code");
+    params.add("client_id", clientId);
+    params.add("redirect_uri", redirectUri);
+    params.add("code", authCode);
 
-        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+    HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
 
-        ResponseEntity<KakaoTokenResponse> response = restTemplate.exchange(
-                tokenUrl, HttpMethod.POST, request, KakaoTokenResponse.class
-        );
+    ResponseEntity<KakaoTokenResponse> response = restTemplate.exchange(
+        tokenUrl, HttpMethod.POST, request, KakaoTokenResponse.class
+    );
 
-        return response.getBody();
-    }
+    return response.getBody();
+  }
 
 
-    public KakaoUserResponse getUserInfo(String accessToken) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.set("Authorization", "Bearer " + accessToken);
+  public KakaoUserResponse getUserInfo(String accessToken) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("Authorization", "Bearer " + accessToken);
 
-        HttpEntity<Void> request = new HttpEntity<>(headers);
-        ResponseEntity<KakaoUserResponse> response = restTemplate.exchange(
-                userInfoUrl,
-                HttpMethod.GET,
-                request,
-                KakaoUserResponse.class
-        );
+    HttpEntity<Void> request = new HttpEntity<>(headers);
+    ResponseEntity<KakaoUserResponse> response = restTemplate.exchange(
+        userInfoUrl,
+        HttpMethod.GET,
+        request,
+        KakaoUserResponse.class
+    );
 
-        return response.getBody();
-    }
+    return response.getBody();
+  }
 }

--- a/src/main/java/com/zb/meeteat/external/kakao/KakaoTokenResponse.java
+++ b/src/main/java/com/zb/meeteat/external/kakao/KakaoTokenResponse.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 
 @Getter
 public class KakaoTokenResponse {
-    @JsonProperty("access_token")
-    private String accessToken;
+
+  @JsonProperty("access_token")
+  private String accessToken;
 }

--- a/src/main/java/com/zb/meeteat/external/kakao/KakaoUserResponse.java
+++ b/src/main/java/com/zb/meeteat/external/kakao/KakaoUserResponse.java
@@ -6,12 +6,13 @@ import lombok.Getter;
 @Getter
 public class KakaoUserResponse {
 
-    @JsonProperty("kakao_account")
-    private KakaoAccount kakaoAccount;
+  @JsonProperty("kakao_account")
+  private KakaoAccount kakaoAccount;
 
-    @Getter
-    public static class KakaoAccount {
-        private String email;
-        private String nickname;
-    }
+  @Getter
+  public static class KakaoAccount {
+
+    private String email;
+    private String nickname;
+  }
 }

--- a/src/main/java/com/zb/meeteat/external/naver/NaverAuthClient.java
+++ b/src/main/java/com/zb/meeteat/external/naver/NaverAuthClient.java
@@ -1,69 +1,72 @@
 package com.zb.meeteat.external.naver;
 
+import java.util.Collections;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.*;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.Collections;
-
 @Component
 @RequiredArgsConstructor
 public class NaverAuthClient {
 
-    @Value("${naver.auth.token-url}")
-    private String tokenUrl;
+  @Value("${naver.auth.token-url}")
+  private String tokenUrl;
 
-    @Value("${naver.auth.user-info-url}")
-    private String userInfoUrl;
+  @Value("${naver.auth.user-info-url}")
+  private String userInfoUrl;
 
-    @Value("${naver.auth.client-id}")
-    private String clientId;
+  @Value("${naver.auth.client-id}")
+  private String clientId;
 
-    @Value("${naver.auth.client-secret}")
-    private String clientSecret;
+  @Value("${naver.auth.client-secret}")
+  private String clientSecret;
 
-    @Value("${naver.auth.redirect-uri}")
-    private String redirectUri;
+  @Value("${naver.auth.redirect-uri}")
+  private String redirectUri;
 
-    private final RestTemplate restTemplate = new RestTemplate();
+  private final RestTemplate restTemplate = new RestTemplate();
 
-    public NaverTokenResponse getToken(String authCode) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-        headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+  public NaverTokenResponse getToken(String authCode) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+    headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
 
-        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        params.add("grant_type", "authorization_code");
-        params.add("client_id", clientId);
-        params.add("client_secret", clientSecret);
-        params.add("code", authCode);
-        params.add("state", "random-state");
+    MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+    params.add("grant_type", "authorization_code");
+    params.add("client_id", clientId);
+    params.add("client_secret", clientSecret);
+    params.add("code", authCode);
+    params.add("state", "random-state");
 
-        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+    HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
 
-        ResponseEntity<NaverTokenResponse> response = restTemplate.exchange(
-                tokenUrl, HttpMethod.POST, request, NaverTokenResponse.class
-        );
+    ResponseEntity<NaverTokenResponse> response = restTemplate.exchange(
+        tokenUrl, HttpMethod.POST, request, NaverTokenResponse.class
+    );
 
-        return response.getBody();
-    }
+    return response.getBody();
+  }
 
-    public NaverUserResponse getUserInfo(String accessToken) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.set("Authorization", "Bearer " + accessToken);
+  public NaverUserResponse getUserInfo(String accessToken) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("Authorization", "Bearer " + accessToken);
 
-        HttpEntity<Void> request = new HttpEntity<>(headers);
-        ResponseEntity<NaverUserResponse> response = restTemplate.exchange(
-                userInfoUrl,
-                HttpMethod.GET,
-                request,
-                NaverUserResponse.class
-        );
+    HttpEntity<Void> request = new HttpEntity<>(headers);
+    ResponseEntity<NaverUserResponse> response = restTemplate.exchange(
+        userInfoUrl,
+        HttpMethod.GET,
+        request,
+        NaverUserResponse.class
+    );
 
-        return response.getBody();
-    }
+    return response.getBody();
+  }
 }

--- a/src/main/java/com/zb/meeteat/external/naver/NaverTokenResponse.java
+++ b/src/main/java/com/zb/meeteat/external/naver/NaverTokenResponse.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 
 @Getter
 public class NaverTokenResponse {
-    @JsonProperty("access_token")
-    private String accessToken;
+
+  @JsonProperty("access_token")
+  private String accessToken;
 }

--- a/src/main/java/com/zb/meeteat/external/naver/NaverUserResponse.java
+++ b/src/main/java/com/zb/meeteat/external/naver/NaverUserResponse.java
@@ -6,13 +6,14 @@ import lombok.Getter;
 @Getter
 public class NaverUserResponse {
 
-    @JsonProperty("response")
-    private Response response;
+  @JsonProperty("response")
+  private Response response;
 
-    @Getter
-    public static class Response {
-        private String id;
-        private String email;
-        private String nickname;
-    }
+  @Getter
+  public static class Response {
+
+    private String id;
+    private String email;
+    private String nickname;
+  }
 }

--- a/src/main/java/com/zb/meeteat/jwt/JwtFilter.java
+++ b/src/main/java/com/zb/meeteat/jwt/JwtFilter.java
@@ -3,7 +3,7 @@ package com.zb.meeteat.jwt;
 import com.zb.meeteat.domain.user.entity.User;
 import com.zb.meeteat.domain.user.repository.UserRepository;
 import com.zb.meeteat.exception.CustomException;
-import com.zb.meeteat.exception.ErrorCode;
+import com.zb.meeteat.exception.UserErrorCode;
 import com.zb.meeteat.security.UserDetailsImpl;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -38,14 +38,14 @@ public class JwtFilter extends OncePerRequestFilter {
 
             // 1. 블랙리스트 체크
             if (jwtUtil.isBlacklisted(jwt)) {
-                throw new CustomException(ErrorCode.INVALID_TOKEN);
+                throw new CustomException(UserErrorCode.INVALID_TOKEN);
             }
 
             // 2. JWT 유효성 검사
             if (jwtUtil.validateToken(jwt)) {
                 Long userId = jwtUtil.getUserId(jwt); // 토큰에서 사용자 ID 가져오기
                 User user = userRepository.findById(userId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+                        .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
 
                 // 3. SecurityContext에 인증 정보 저장
                 UserDetails userDetails = new UserDetailsImpl(user);

--- a/src/main/java/com/zb/meeteat/jwt/JwtFilter.java
+++ b/src/main/java/com/zb/meeteat/jwt/JwtFilter.java
@@ -9,6 +9,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -16,45 +17,44 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import java.io.IOException;
-
 @Component
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
 
-    private final JwtUtil jwtUtil;
-    private final UserRepository userRepository;
+  private final JwtUtil jwtUtil;
+  private final UserRepository userRepository;
 
-    @Override
-    protected void doFilterInternal(HttpServletRequest request,
-                                    HttpServletResponse response,
-                                    FilterChain chain)
-            throws ServletException, IOException {
+  @Override
+  protected void doFilterInternal(HttpServletRequest request,
+      HttpServletResponse response,
+      FilterChain chain)
+      throws ServletException, IOException {
 
-        String token = request.getHeader("Authorization");
+    String token = request.getHeader("Authorization");
 
-        if (token != null && token.startsWith("Bearer ")) {
-            String jwt = token.replace("Bearer ", "");
+    if (token != null && token.startsWith("Bearer ")) {
+      String jwt = token.replace("Bearer ", "");
 
-            // 1. 블랙리스트 체크
-            if (jwtUtil.isBlacklisted(jwt)) {
-                throw new UserCustomException(UserErrorCode.INVALID_TOKEN);
-            }
+      // 1. 블랙리스트 체크
+      if (jwtUtil.isBlacklisted(jwt)) {
+        throw new UserCustomException(UserErrorCode.INVALID_TOKEN);
+      }
 
-            // 2. JWT 유효성 검사
-            if (jwtUtil.validateToken(jwt)) {
-                Long userId = jwtUtil.getUserId(jwt); // 토큰에서 사용자 ID 가져오기
-                User user = userRepository.findById(userId)
-                        .orElseThrow(() -> new UserCustomException(UserErrorCode.USER_NOT_FOUND));
+      // 2. JWT 유효성 검사
+      if (jwtUtil.validateToken(jwt)) {
+        Long userId = jwtUtil.getUserId(jwt); // 토큰에서 사용자 ID 가져오기
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new UserCustomException(UserErrorCode.USER_NOT_FOUND));
 
-                // 3. SecurityContext에 인증 정보 저장
-                UserDetails userDetails = new UserDetailsImpl(user);
-                UsernamePasswordAuthenticationToken authentication =
-                        new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
-                SecurityContextHolder.getContext().setAuthentication(authentication);
-            }
-        }
-
-        chain.doFilter(request, response);
+        // 3. SecurityContext에 인증 정보 저장
+        UserDetails userDetails = new UserDetailsImpl(user);
+        UsernamePasswordAuthenticationToken authentication =
+            new UsernamePasswordAuthenticationToken(userDetails, null,
+                userDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+      }
     }
+
+    chain.doFilter(request, response);
+  }
 }

--- a/src/main/java/com/zb/meeteat/jwt/JwtFilter.java
+++ b/src/main/java/com/zb/meeteat/jwt/JwtFilter.java
@@ -1,36 +1,57 @@
 package com.zb.meeteat.jwt;
 
+import com.zb.meeteat.domain.user.entity.User;
+import com.zb.meeteat.domain.user.repository.UserRepository;
 import com.zb.meeteat.exception.CustomException;
 import com.zb.meeteat.exception.ErrorCode;
+import com.zb.meeteat.security.UserDetailsImpl;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+@Component
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
+    private final UserRepository userRepository;
 
     @Override
-    protected void doFilterInternal(@NonNull HttpServletRequest request,
-                                    @NonNull HttpServletResponse response,
-                                    @NonNull FilterChain chain)
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain chain)
             throws ServletException, IOException {
-
 
         String token = request.getHeader("Authorization");
 
         if (token != null && token.startsWith("Bearer ")) {
             String jwt = token.replace("Bearer ", "");
 
+            // 1. 블랙리스트 체크
             if (jwtUtil.isBlacklisted(jwt)) {
                 throw new CustomException(ErrorCode.INVALID_TOKEN);
+            }
+
+            // 2. JWT 유효성 검사
+            if (jwtUtil.validateToken(jwt)) {
+                Long userId = jwtUtil.getUserId(jwt); // 토큰에서 사용자 ID 가져오기
+                User user = userRepository.findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+                // 3. SecurityContext에 인증 정보 저장
+                UserDetails userDetails = new UserDetailsImpl(user);
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                SecurityContextHolder.getContext().setAuthentication(authentication);
             }
         }
 

--- a/src/main/java/com/zb/meeteat/jwt/JwtUtil.java
+++ b/src/main/java/com/zb/meeteat/jwt/JwtUtil.java
@@ -5,84 +5,85 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
+import java.util.Base64;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+import javax.crypto.SecretKey;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
-import javax.crypto.SecretKey;
-import java.util.Base64;
-import java.util.Date;
-import java.util.concurrent.TimeUnit;
-
 @Slf4j
 @Service
 public class JwtUtil {
 
-    private final RedisTemplate<String, String> redisTemplate;
-    private final SecretKey key;
-    private final long EXPIRATION_TIME = 1000 * 60 * 60 * 24; // 24시간 유지
+  private final RedisTemplate<String, String> redisTemplate;
+  private final SecretKey key;
+  private final long EXPIRATION_TIME = 1000 * 60 * 60 * 24; // 24시간 유지
 
-    public JwtUtil(@Value("${spring.jwt.secret}") String secretKey, RedisTemplate<String, String> redisTemplate) {
-        this.redisTemplate = redisTemplate;
-        try {
-            byte[] decodedKey = Base64.getDecoder().decode(secretKey);
-            this.key = Keys.hmacShaKeyFor(decodedKey);
-        } catch (IllegalArgumentException e) {
-            throw new RuntimeException("Invalid Base64-encoded secret key. Please check your environment variable.", e);
-        }
+  public JwtUtil(@Value("${spring.jwt.secret}") String secretKey,
+      RedisTemplate<String, String> redisTemplate) {
+    this.redisTemplate = redisTemplate;
+    try {
+      byte[] decodedKey = Base64.getDecoder().decode(secretKey);
+      this.key = Keys.hmacShaKeyFor(decodedKey);
+    } catch (IllegalArgumentException e) {
+      throw new RuntimeException(
+          "Invalid Base64-encoded secret key. Please check your environment variable.", e);
     }
+  }
 
-    public String generateToken(User user) {
-        return Jwts.builder()
-                .setSubject(user.getEmail())
-                .claim("userId", user.getId())
-                .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION_TIME))
-                .signWith(key)
-                .compact();
+  public String generateToken(User user) {
+    return Jwts.builder()
+        .setSubject(user.getEmail())
+        .claim("userId", user.getId())
+        .setIssuedAt(new Date())
+        .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION_TIME))
+        .signWith(key)
+        .compact();
+  }
+
+  public Long getUserId(String token) {
+    return Jwts.parserBuilder()
+        .setSigningKey(key)
+        .build()
+        .parseClaimsJws(token)
+        .getBody()
+        .get("userId", Long.class);
+  }
+
+  public boolean validateToken(String token) {
+    try {
+      if (isBlacklisted(token)) {
+        log.warn("블랙리스트에 등록된 토큰입니다: {}", token);
+        return false;
+      }
+      Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+      return true;
+    } catch (JwtException | IllegalArgumentException e) {
+      log.warn("JWT 검증 실패: {} - {}", token, e.getMessage());
+      return false;
     }
+  }
 
-    public Long getUserId(String token) {
-        return Jwts.parserBuilder()
-                .setSigningKey(key)
-                .build()
-                .parseClaimsJws(token)
-                .getBody()
-                .get("userId", Long.class);
-    }
+  public void blacklistToken(String token) {
+    long expiration = Math.max(getExpiration(token), 1000);
+    redisTemplate.opsForValue().set(token, "blacklisted", expiration, TimeUnit.MILLISECONDS);
+  }
 
-    public boolean validateToken(String token) {
-        try {
-            if (isBlacklisted(token)) {
-                log.warn("블랙리스트에 등록된 토큰입니다: {}", token);
-                return false;
-            }
-            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
-            return true;
-        } catch (JwtException | IllegalArgumentException e) {
-            log.warn("JWT 검증 실패: {} - {}", token, e.getMessage());
-            return false;
-        }
-    }
+  public long getExpiration(String token) {
+    Claims claims = Jwts.parserBuilder()
+        .setSigningKey(key)
+        .build()
+        .parseClaimsJws(token)
+        .getBody();
 
-    public void blacklistToken(String token) {
-        long expiration = Math.max(getExpiration(token), 1000);
-        redisTemplate.opsForValue().set(token, "blacklisted", expiration, TimeUnit.MILLISECONDS);
-    }
+    return claims.getExpiration().getTime() - System.currentTimeMillis();
+  }
 
-    public long getExpiration(String token) {
-        Claims claims = Jwts.parserBuilder()
-                .setSigningKey(key)
-                .build()
-                .parseClaimsJws(token)
-                .getBody();
-
-        return claims.getExpiration().getTime() - System.currentTimeMillis();
-    }
-
-    public boolean isBlacklisted(String token) {
-        return Boolean.TRUE.equals(redisTemplate.hasKey(token));
-    }
+  public boolean isBlacklisted(String token) {
+    return Boolean.TRUE.equals(redisTemplate.hasKey(token));
+  }
 
 }

--- a/src/main/java/com/zb/meeteat/security/UserDetailsImpl.java
+++ b/src/main/java/com/zb/meeteat/security/UserDetailsImpl.java
@@ -1,0 +1,35 @@
+package com.zb.meeteat.security;
+
+import com.zb.meeteat.domain.user.entity.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public class UserDetailsImpl implements UserDetails {
+    private final User user;
+
+    public UserDetailsImpl(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(() -> user.getRole().name());
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    public User getUser() {
+        return user;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,4 @@
 spring.application.name=MeetEat
-
 spring.profiles.active=default
 # MySQL
 spring.datasource.url=${DB_URL}
@@ -31,14 +30,12 @@ naver.auth.user-info-url=https://openapi.naver.com/v1/nid/me
 naver.auth.client-id=${NAVER_CLIENT_ID}
 naver.auth.client-secret=${NAVER_CLIENT_SECRET}
 naver.auth.redirect-uri=http://localhost:8080/api/users/signin/naver
-
 # AWS s3 bucket
 cloud.aws.credentials.access-key=${AWS_ACCESSKEY}
 cloud.aws.credentials.secret-key=${AWS_SECRETKEY}
 cloud.aws.bucketName=${AWS_BUCKETNAME}
 cloud.aws.region.static=${REGION}
 cloud.aws.stack.auto-=false
-
 # redis
 spring.data.redis.host=localhost
 spring.data.redis.port=6379

--- a/src/test/java/com/zb/meeteat/domain/user/dto/SignupRequestDtoTest.java
+++ b/src/test/java/com/zb/meeteat/domain/user/dto/SignupRequestDtoTest.java
@@ -1,122 +1,122 @@
 package com.zb.meeteat.domain.user.dto;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.Set;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class SignupRequestDtoTest {
 
-    private Validator validator;
+  private Validator validator;
 
-    @BeforeEach
-    void setUp() {
-        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
-        validator = factory.getValidator();
-    }
+  @BeforeEach
+  void setUp() {
+    ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+    validator = factory.getValidator();
+  }
 
-    /**
-     * 기본 유효한 회원가입 요청을 생성하는 메서드
-     */
-    private SignupRequestDto createValidSignupRequest() {
-        return SignupRequestDto.builder()
-                .email("valid@example.com")
-                .password("Password123!")
-                .nickname("nickname")
-                .build();
-    }
+  /**
+   * 기본 유효한 회원가입 요청을 생성하는 메서드
+   */
+  private SignupRequestDto createValidSignupRequest() {
+    return SignupRequestDto.builder()
+        .email("valid@example.com")
+        .password("Password123!")
+        .nickname("nickname")
+        .build();
+  }
 
-    /**
-     * 커스텀 필드 값을 설정할 수 있는 빌더 메서드
-     */
-    private SignupRequestDto.SignupRequestDtoBuilder baseSignupRequestBuilder() {
-        return SignupRequestDto.builder()
-                .email("valid@example.com")
-                .password("Password123!")
-                .nickname("nickname");
-    }
+  /**
+   * 커스텀 필드 값을 설정할 수 있는 빌더 메서드
+   */
+  private SignupRequestDto.SignupRequestDtoBuilder baseSignupRequestBuilder() {
+    return SignupRequestDto.builder()
+        .email("valid@example.com")
+        .password("Password123!")
+        .nickname("nickname");
+  }
 
-    @Test
-    @DisplayName("유효한 회원가입 요청은 검증 오류가 발생하지 않아야 한다")
-    void validSignupRequest_shouldPassValidation() {
-        // given
-        SignupRequestDto requestDto = createValidSignupRequest();
+  @Test
+  @DisplayName("유효한 회원가입 요청은 검증 오류가 발생하지 않아야 한다")
+  void validSignupRequest_shouldPassValidation() {
+    // given
+    SignupRequestDto requestDto = createValidSignupRequest();
 
-        // when
-        Set<ConstraintViolation<SignupRequestDto>> violations = validator.validate(requestDto);
+    // when
+    Set<ConstraintViolation<SignupRequestDto>> violations = validator.validate(requestDto);
 
-        // then
-        assertThat(violations).isEmpty();
-    }
+    // then
+    assertThat(violations).isEmpty();
+  }
 
-    @Test
-    @DisplayName("이메일 형식이 올바르지 않으면 검증 실패")
-    void invalidEmail_shouldFailValidation() {
-        // given
-        SignupRequestDto requestDto = baseSignupRequestBuilder()
-                .email("invalid-email") // 잘못된 이메일 형식
-                .build();
+  @Test
+  @DisplayName("이메일 형식이 올바르지 않으면 검증 실패")
+  void invalidEmail_shouldFailValidation() {
+    // given
+    SignupRequestDto requestDto = baseSignupRequestBuilder()
+        .email("invalid-email") // 잘못된 이메일 형식
+        .build();
 
-        // when
-        Set<ConstraintViolation<SignupRequestDto>> violations = validator.validate(requestDto);
+    // when
+    Set<ConstraintViolation<SignupRequestDto>> violations = validator.validate(requestDto);
 
-        // then
-        assertThat(violations).isNotEmpty();
-        assertThat(violations).anyMatch(v -> v.getMessage().equals("유효한 이메일 형식을 입력하세요."));
-    }
+    // then
+    assertThat(violations).isNotEmpty();
+    assertThat(violations).anyMatch(v -> v.getMessage().equals("유효한 이메일 형식을 입력하세요."));
+  }
 
-    @Test
-    @DisplayName("비밀번호가 누락되면 검증 실패")
-    void missingPassword_shouldFailValidation() {
-        // given
-        SignupRequestDto requestDto = baseSignupRequestBuilder()
-                .password(null) // 비밀번호 누락
-                .build();
+  @Test
+  @DisplayName("비밀번호가 누락되면 검증 실패")
+  void missingPassword_shouldFailValidation() {
+    // given
+    SignupRequestDto requestDto = baseSignupRequestBuilder()
+        .password(null) // 비밀번호 누락
+        .build();
 
-        // when
-        Set<ConstraintViolation<SignupRequestDto>> violations = validator.validate(requestDto);
+    // when
+    Set<ConstraintViolation<SignupRequestDto>> violations = validator.validate(requestDto);
 
-        // then
-        assertThat(violations).isNotEmpty();
-        assertThat(violations).anyMatch(v -> v.getMessage().equals("비밀번호는 필수 입력 항목입니다."));
-    }
+    // then
+    assertThat(violations).isNotEmpty();
+    assertThat(violations).anyMatch(v -> v.getMessage().equals("비밀번호는 필수 입력 항목입니다."));
+  }
 
-    @Test
-    @DisplayName("닉네임이 누락되면 검증 실패")
-    void missingNickname_shouldFailValidation() {
-        // given
-        SignupRequestDto requestDto = baseSignupRequestBuilder()
-                .nickname(null) // 닉네임 누락
-                .build();
+  @Test
+  @DisplayName("닉네임이 누락되면 검증 실패")
+  void missingNickname_shouldFailValidation() {
+    // given
+    SignupRequestDto requestDto = baseSignupRequestBuilder()
+        .nickname(null) // 닉네임 누락
+        .build();
 
-        // when
-        Set<ConstraintViolation<SignupRequestDto>> violations = validator.validate(requestDto);
+    // when
+    Set<ConstraintViolation<SignupRequestDto>> violations = validator.validate(requestDto);
 
-        // then
-        assertThat(violations).isNotEmpty();
-        assertThat(violations).anyMatch(v -> v.getMessage().equals("닉네임은 필수 입력 항목입니다."));
-    }
+    // then
+    assertThat(violations).isNotEmpty();
+    assertThat(violations).anyMatch(v -> v.getMessage().equals("닉네임은 필수 입력 항목입니다."));
+  }
 
-    @Test
-    @DisplayName("비밀번호가 정규식을 충족하지 않으면 검증 실패")
-    void invalidPassword_shouldFailValidation() {
-        // given
-        SignupRequestDto requestDto = baseSignupRequestBuilder()
-                .password("password") // 정규식 조건 미충족 (특수문자 없음)
-                .build();
+  @Test
+  @DisplayName("비밀번호가 정규식을 충족하지 않으면 검증 실패")
+  void invalidPassword_shouldFailValidation() {
+    // given
+    SignupRequestDto requestDto = baseSignupRequestBuilder()
+        .password("password") // 정규식 조건 미충족 (특수문자 없음)
+        .build();
 
-        // when
-        Set<ConstraintViolation<SignupRequestDto>> violations = validator.validate(requestDto);
+    // when
+    Set<ConstraintViolation<SignupRequestDto>> violations = validator.validate(requestDto);
 
-        // then
-        assertThat(violations).isNotEmpty();
-        assertThat(violations).anyMatch(v -> v.getMessage().equals("비밀번호는 최소 8자 이상이며, 영문, 숫자, 특수문자를 각각 하나 이상 포함해야 합니다."));
-    }
+    // then
+    assertThat(violations).isNotEmpty();
+    assertThat(violations).anyMatch(
+        v -> v.getMessage().equals("비밀번호는 최소 8자 이상이며, 영문, 숫자, 특수문자를 각각 하나 이상 포함해야 합니다."));
+  }
 }

--- a/src/test/java/com/zb/meeteat/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/zb/meeteat/domain/user/repository/UserRepositoryTest.java
@@ -1,5 +1,8 @@
 package com.zb.meeteat.domain.user.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.zb.meeteat.domain.user.entity.Role;
 import com.zb.meeteat.domain.user.entity.SignUpType;
 import com.zb.meeteat.domain.user.entity.User;
@@ -7,163 +10,159 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.DataIntegrityViolationException;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DataJpaTest
 class UserRepositoryTest {
 
-    @Autowired
-    private UserRepository userRepository;
+  @Autowired
+  private UserRepository userRepository;
 
-    /**
-     * 기본적인 User 객체를 생성하는 메서드
-     */
-    private User createUser(String email, String password, String nickname) {
-        return User.builder()
-                .email(email)
-                .password(password)
-                .nickname(nickname)
-                .role(Role.USER)
-                .signupType(SignUpType.EMAIL)
-                .build();
-    }
+  /**
+   * 기본적인 User 객체를 생성하는 메서드
+   */
+  private User createUser(String email, String password, String nickname) {
+    return User.builder()
+        .email(email)
+        .password(password)
+        .nickname(nickname)
+        .role(Role.USER)
+        .signupType(SignUpType.EMAIL)
+        .build();
+  }
 
-    @Test
-    @DisplayName("이메일로 사용자 조회 테스트")
-    void findByEmailTest() {
-        // given
-        User user = createUser("test@example.com", "password123", "testuser");
-        userRepository.saveAndFlush(user);
+  @Test
+  @DisplayName("이메일로 사용자 조회 테스트")
+  void findByEmailTest() {
+    // given
+    User user = createUser("test@example.com", "password123", "testuser");
+    userRepository.saveAndFlush(user);
 
-        // when
-        User foundUser = userRepository.findByEmail("test@example.com")
-                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+    // when
+    User foundUser = userRepository.findByEmail("test@example.com")
+        .orElseThrow(() -> new IllegalArgumentException("User not found"));
 
-        // then
-        assertThat(foundUser.getEmail()).isEqualTo("test@example.com");
-        assertThat(foundUser.getNickname()).isEqualTo("testuser");
-    }
+    // then
+    assertThat(foundUser.getEmail()).isEqualTo("test@example.com");
+    assertThat(foundUser.getNickname()).isEqualTo("testuser");
+  }
 
-    @Test
-    @DisplayName("존재하지 않는 이메일로 조회 시 예외 발생")
-    void findByNonExistingEmailTest() {
-        assertThatThrownBy(() -> userRepository.findByEmail("nonexistent@example.com")
-                .orElseThrow(() -> new IllegalArgumentException("User not found")))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("User not found");
-    }
+  @Test
+  @DisplayName("존재하지 않는 이메일로 조회 시 예외 발생")
+  void findByNonExistingEmailTest() {
+    assertThatThrownBy(() -> userRepository.findByEmail("nonexistent@example.com")
+        .orElseThrow(() -> new IllegalArgumentException("User not found")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("User not found");
+  }
 
-    @Test
-    @DisplayName("닉네임으로 사용자 조회 테스트")
-    void findByNicknameTest() {
-        // given
-        User user = createUser("nickname@example.com", "password123", "uniqueNickname");
-        userRepository.saveAndFlush(user);
+  @Test
+  @DisplayName("닉네임으로 사용자 조회 테스트")
+  void findByNicknameTest() {
+    // given
+    User user = createUser("nickname@example.com", "password123", "uniqueNickname");
+    userRepository.saveAndFlush(user);
 
-        // when
-        User foundUser = userRepository.findByNickname("uniqueNickname")
-                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+    // when
+    User foundUser = userRepository.findByNickname("uniqueNickname")
+        .orElseThrow(() -> new IllegalArgumentException("User not found"));
 
-        // then
-        assertThat(foundUser.getNickname()).isEqualTo("uniqueNickname");
-        assertThat(foundUser.getEmail()).isEqualTo("nickname@example.com");
-    }
+    // then
+    assertThat(foundUser.getNickname()).isEqualTo("uniqueNickname");
+    assertThat(foundUser.getEmail()).isEqualTo("nickname@example.com");
+  }
 
-    @Test
-    @DisplayName("존재하지 않는 닉네임으로 조회 시 예외 발생")
-    void findByNonExistingNicknameTest() {
-        assertThatThrownBy(() -> userRepository.findByNickname("nonexistentNickname")
-                .orElseThrow(() -> new IllegalArgumentException("User not found")))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("User not found");
-    }
+  @Test
+  @DisplayName("존재하지 않는 닉네임으로 조회 시 예외 발생")
+  void findByNonExistingNicknameTest() {
+    assertThatThrownBy(() -> userRepository.findByNickname("nonexistentNickname")
+        .orElseThrow(() -> new IllegalArgumentException("User not found")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("User not found");
+  }
 
-    @Test
-    @DisplayName("사용자 저장 테스트")
-    void savedUserTest() {
-        // given
-        User user = createUser("save@example.com", "password123", "savedUser");
+  @Test
+  @DisplayName("사용자 저장 테스트")
+  void savedUserTest() {
+    // given
+    User user = createUser("save@example.com", "password123", "savedUser");
 
-        // when
-        User savedUser = userRepository.save(user);
+    // when
+    User savedUser = userRepository.save(user);
 
-        // then
-        assertThat(savedUser.getId()).isNotNull();
-        assertThat(savedUser.getEmail()).isEqualTo("save@example.com");
-        assertThat(savedUser.getNickname()).isEqualTo("savedUser");
-    }
+    // then
+    assertThat(savedUser.getId()).isNotNull();
+    assertThat(savedUser.getEmail()).isEqualTo("save@example.com");
+    assertThat(savedUser.getNickname()).isEqualTo("savedUser");
+  }
 
-    @Test
-    @DisplayName("이메일 존재 여부 확인 테스트")
-    void existsByEmailTest() {
-        // given
-        User user = createUser("exists@example.com", "password123", "existsUser");
-        userRepository.saveAndFlush(user);
+  @Test
+  @DisplayName("이메일 존재 여부 확인 테스트")
+  void existsByEmailTest() {
+    // given
+    User user = createUser("exists@example.com", "password123", "existsUser");
+    userRepository.saveAndFlush(user);
 
-        // when
-        boolean exists = userRepository.existsByEmail("exists@example.com");
+    // when
+    boolean exists = userRepository.existsByEmail("exists@example.com");
 
-        // then
-        assertThat(exists).isTrue();
-    }
+    // then
+    assertThat(exists).isTrue();
+  }
 
-    @Test
-    @DisplayName("닉네임 존재 여부 확인 테스트")
-    void existsByNicknameTest() {
-        // given
-        User user = createUser("nicknameexists@example.com", "password123", "nicknameExists");
-        userRepository.saveAndFlush(user);
+  @Test
+  @DisplayName("닉네임 존재 여부 확인 테스트")
+  void existsByNicknameTest() {
+    // given
+    User user = createUser("nicknameexists@example.com", "password123", "nicknameExists");
+    userRepository.saveAndFlush(user);
 
-        // when
-        boolean exists = userRepository.existsByNickname("nicknameExists");
+    // when
+    boolean exists = userRepository.existsByNickname("nicknameExists");
 
-        // then
-        assertThat(exists).isTrue();
-    }
+    // then
+    assertThat(exists).isTrue();
+  }
 
-    @Test
-    @DisplayName("사용자 삭제 테스트")
-    void deleteUserTest() {
-        // given
-        User user = createUser("delete@example.com", "password123", "deleteUser");
-        userRepository.saveAndFlush(user);
+  @Test
+  @DisplayName("사용자 삭제 테스트")
+  void deleteUserTest() {
+    // given
+    User user = createUser("delete@example.com", "password123", "deleteUser");
+    userRepository.saveAndFlush(user);
 
-        // when
-        userRepository.delete(user);
+    // when
+    userRepository.delete(user);
 
-        // then
-        assertThat(userRepository.findByEmail("delete@example.com")).isEmpty();
-    }
+    // then
+    assertThat(userRepository.findByEmail("delete@example.com")).isEmpty();
+  }
 
-    @Test
-    @DisplayName("중복된 이메일 저장 시 예외 발생 테스트")
-    void duplicateEmailTest() {
-        // given
-        User user1 = createUser("duplicate@example.com", "password123", "user1");
-        User user2 = createUser("duplicate@example.com", "password456", "user2");
+  @Test
+  @DisplayName("중복된 이메일 저장 시 예외 발생 테스트")
+  void duplicateEmailTest() {
+    // given
+    User user1 = createUser("duplicate@example.com", "password123", "user1");
+    User user2 = createUser("duplicate@example.com", "password456", "user2");
 
-        userRepository.saveAndFlush(user1);
+    userRepository.saveAndFlush(user1);
 
-        // when, then
-        assertThatThrownBy(() -> userRepository.saveAndFlush(user2))
-                .isInstanceOf(DataIntegrityViolationException.class);
-    }
+    // when, then
+    assertThatThrownBy(() -> userRepository.saveAndFlush(user2))
+        .isInstanceOf(DataIntegrityViolationException.class);
+  }
 
-    @Test
-    @DisplayName("중복된 닉네임 저장 시 예외 발생 테스트")
-    void duplicateNicknameTest() {
-        // given
-        User user1 = createUser("unique1@example.com", "password456", "duplicateNickname");
-        User user2 = createUser("unique2@example.com", "password456", "duplicateNickname");
+  @Test
+  @DisplayName("중복된 닉네임 저장 시 예외 발생 테스트")
+  void duplicateNicknameTest() {
+    // given
+    User user1 = createUser("unique1@example.com", "password456", "duplicateNickname");
+    User user2 = createUser("unique2@example.com", "password456", "duplicateNickname");
 
-        userRepository.saveAndFlush(user1);
+    userRepository.saveAndFlush(user1);
 
-        // when, then
-        assertThatThrownBy(() -> userRepository.saveAndFlush(user2))
-                .isInstanceOf(DataIntegrityViolationException.class);
-    }
+    // when, then
+    assertThatThrownBy(() -> userRepository.saveAndFlush(user2))
+        .isInstanceOf(DataIntegrityViolationException.class);
+  }
 }

--- a/src/test/java/com/zb/meeteat/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/zb/meeteat/domain/user/service/UserServiceTest.java
@@ -1,5 +1,10 @@
 package com.zb.meeteat.domain.user.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
 import com.zb.meeteat.domain.user.dto.SignupRequestDto;
 import com.zb.meeteat.domain.user.entity.Role;
 import com.zb.meeteat.domain.user.entity.SignUpType;
@@ -13,86 +18,84 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
-
 class UserServiceTest {
 
-    @Mock
-    private UserRepository userRepository;
+  @Mock
+  private UserRepository userRepository;
 
-    @Mock
-    private PasswordEncoder passwordEncoder;
+  @Mock
+  private PasswordEncoder passwordEncoder;
 
-    @InjectMocks
-    private AuthService userService;
+  @InjectMocks
+  private AuthService userService;
 
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
 
-    /**
-     * 회원가입 요청을 위한 기본 DTO 생성 메서드
-     */
-    private SignupRequestDto createSignupRequestDto(String email, String password, String nickname) {
-        return SignupRequestDto.builder()
-                .email(email)
-                .password(password)
-                .nickname(nickname)
-                .build();
-    }
+  /**
+   * 회원가입 요청을 위한 기본 DTO 생성 메서드
+   */
+  private SignupRequestDto createSignupRequestDto(String email, String password, String nickname) {
+    return SignupRequestDto.builder()
+        .email(email)
+        .password(password)
+        .nickname(nickname)
+        .build();
+  }
 
-    @Test
-    @DisplayName("성공적인 회원가입 테스트")
-    void signup_success() {
-        // given
-        SignupRequestDto requestDto = createSignupRequestDto("test@example.com", "Password123!", "nickname");
+  @Test
+  @DisplayName("성공적인 회원가입 테스트")
+  void signup_success() {
+    // given
+    SignupRequestDto requestDto = createSignupRequestDto("test@example.com", "Password123!",
+        "nickname");
 
-        when(userRepository.existsByEmail(requestDto.getEmail())).thenReturn(false);
-        when(userRepository.existsByNickname(requestDto.getNickname())).thenReturn(false);
-        when(passwordEncoder.encode(requestDto.getPassword())).thenReturn("encodedPassword");
-        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+    when(userRepository.existsByEmail(requestDto.getEmail())).thenReturn(false);
+    when(userRepository.existsByNickname(requestDto.getNickname())).thenReturn(false);
+    when(passwordEncoder.encode(requestDto.getPassword())).thenReturn("encodedPassword");
+    when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        // when
-        User savedUser = userService.signup(requestDto);
+    // when
+    User savedUser = userService.signup(requestDto);
 
-        // then
-        assertThat(savedUser.getEmail()).isEqualTo(requestDto.getEmail());
-        assertThat(savedUser.getNickname()).isEqualTo(requestDto.getNickname());
-        assertThat(savedUser.getPassword()).isEqualTo("encodedPassword"); // 비밀번호 암호화 확인
-        assertThat(savedUser.getRole()).isEqualTo(Role.USER);
-        assertThat(savedUser.getSignupType()).isEqualTo(SignUpType.EMAIL);
-    }
+    // then
+    assertThat(savedUser.getEmail()).isEqualTo(requestDto.getEmail());
+    assertThat(savedUser.getNickname()).isEqualTo(requestDto.getNickname());
+    assertThat(savedUser.getPassword()).isEqualTo("encodedPassword"); // 비밀번호 암호화 확인
+    assertThat(savedUser.getRole()).isEqualTo(Role.USER);
+    assertThat(savedUser.getSignupType()).isEqualTo(SignUpType.EMAIL);
+  }
 
-    @Test
-    @DisplayName("이메일 중복으로 인한 회원가입 실패")
-    void signupEmailDuplicateFail() {
-        // given
-        SignupRequestDto requestDto = createSignupRequestDto("duplicate@example.com", "Password123!", "nickname");
+  @Test
+  @DisplayName("이메일 중복으로 인한 회원가입 실패")
+  void signupEmailDuplicateFail() {
+    // given
+    SignupRequestDto requestDto = createSignupRequestDto("duplicate@example.com", "Password123!",
+        "nickname");
 
-        when(userRepository.existsByEmail(requestDto.getEmail())).thenReturn(true);
+    when(userRepository.existsByEmail(requestDto.getEmail())).thenReturn(true);
 
-        // when, then
-        assertThatThrownBy(() -> userService.signup(requestDto))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("이미 사용 중인 이메일입니다.");
-    }
+    // when, then
+    assertThatThrownBy(() -> userService.signup(requestDto))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("이미 사용 중인 이메일입니다.");
+  }
 
-    @Test
-    @DisplayName("닉네임 중복으로 인한 회원가입 실패")
-    void signupNicknameDuplicateFail() {
-        // given
-        SignupRequestDto requestDto = createSignupRequestDto("test@example.com", "Password123!", "duplicateNickname");
+  @Test
+  @DisplayName("닉네임 중복으로 인한 회원가입 실패")
+  void signupNicknameDuplicateFail() {
+    // given
+    SignupRequestDto requestDto = createSignupRequestDto("test@example.com", "Password123!",
+        "duplicateNickname");
 
-        when(userRepository.existsByEmail(requestDto.getEmail())).thenReturn(false);
-        when(userRepository.existsByNickname(requestDto.getNickname())).thenReturn(true);
+    when(userRepository.existsByEmail(requestDto.getEmail())).thenReturn(false);
+    when(userRepository.existsByNickname(requestDto.getNickname())).thenReturn(true);
 
-        // when, then
-        assertThatThrownBy(() -> userService.signup(requestDto))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("이미 사용 중인 닉네임입니다.");
-    }
+    // when, then
+    assertThatThrownBy(() -> userService.signup(requestDto))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("이미 사용 중인 닉네임입니다.");
+  }
 }


### PR DESCRIPTION
## Pull Request

### 변경사항

### AS-IS (이전 상태)
- 비밀번호 변경 API 미구현
- 프로필 조회 API 미구현
- 닉네임 변경 API 미구현
- 한줄소개 변경 API 미구현

### TO-BE (변경 후 상태)

#### 비밀번호 변경 (PATCH /api/users/change-password)
- 기존 비밀번호 검증 후 새 비밀번호로 변경
- 비밀번호 형식 검증 (영문, 숫자, 특수문자 포함)
- 비밀번호 암호화 적용

#### 프로필 조회 (GET /api/users/profile)
- 현재 로그인한 사용자의 프로필 정보 반환
- `UserProfileResponse` DTO를 활용하여 데이터 응답
- 필요한 필드: `id`, `email`, `nickname`, `introduce`, `role`, `matchingCount`, `isPenalty`, `createdAt`, `updatedAt`

#### 닉네임 변경 (PATCH /api/users/profile/nickname)
- 닉네임을 새로운 값으로 업데이트
- 닉네임 유효성 검사 (공백 포함 불가, 특수문자 제한)
- 중복 닉네임 여부 확인

#### 한줄소개 변경 (PATCH /api/users/profile/introduce)
- 한줄소개를 새로운 값으로 업데이트
- 50자 이하 제한
---

### 테스트

- [x] 비밀번호 변경 API 테스트 완료 (`PUT /api/users/change-password`)
- [x] 프로필 조회 API 테스트 완료 (`GET /api/users/profile`)
- [x] 닉네임 변경 API 테스트 완료 (`PATCH /api/users/profile/nickname`)
- [x] 한줄소개 변경 API 테스트 완료 (`PATCH /api/users/profile/introduce`)
- [ ] 통합 테스트 추가 예정
- [ ] API 문서화 추가 예정