### PR TITLE
refactor: 식당 조회 정렬 오류 수정, 식당 상세 조회 Response수정, Restaurant Entity 수정

### DIFF
--- a/src/main/java/com/zb/meeteat/domain/restaurant/controller/RestaurantController.java
+++ b/src/main/java/com/zb/meeteat/domain/restaurant/controller/RestaurantController.java
@@ -2,6 +2,7 @@ package com.zb.meeteat.domain.restaurant.controller;
 
 import com.zb.meeteat.domain.restaurant.dto.CreateReviewRequest;
 import com.zb.meeteat.domain.restaurant.dto.RestaurantResponse;
+import com.zb.meeteat.domain.restaurant.dto.RestaurantReviewsResponse;
 import com.zb.meeteat.domain.restaurant.dto.SearchRequest;
 import com.zb.meeteat.domain.restaurant.entity.RestaurantReview;
 import com.zb.meeteat.domain.restaurant.service.RestaurantService;
@@ -49,7 +50,7 @@ public class RestaurantController {
   }
 
   @GetMapping("/{restaurantId}/reviews")
-  public ResponseEntity<Page<RestaurantReview>> getReviews(
+  public ResponseEntity<Page<RestaurantReviewsResponse>> getReviews(
       @PathVariable(name = "restaurantId") Long restaurantId,
       @RequestParam(name = "page", defaultValue = "1") int page,
       @RequestParam(name = "size", defaultValue = "10") int size) {

--- a/src/main/java/com/zb/meeteat/domain/restaurant/dto/RestaurantReviewsResponse.java
+++ b/src/main/java/com/zb/meeteat/domain/restaurant/dto/RestaurantReviewsResponse.java
@@ -1,0 +1,22 @@
+package com.zb.meeteat.domain.restaurant.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RestaurantReviewsResponse {
+  private Long id;
+  private double rating;
+  private String description;
+  private String imgUrl;
+  private String nickname;
+  private String createdAt;
+}

--- a/src/main/java/com/zb/meeteat/domain/restaurant/entity/Restaurant.java
+++ b/src/main/java/com/zb/meeteat/domain/restaurant/entity/Restaurant.java
@@ -22,12 +22,12 @@ public class Restaurant {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
-  private Long kakaomaps_id;
-  private String place_name;
+  private Long kakaomapsId;
+  private String placeName;
   private String phone;
-  private double y;
-  private double x;
-  private String road_address_name;
-  private String category_name;
-  private double rating;
+  private Double y;
+  private Double x;
+  private String roadAddressName;
+  private String categoryName;
+  private Double rating;
 }

--- a/src/main/java/com/zb/meeteat/domain/restaurant/repository/RestaurantRepository.java
+++ b/src/main/java/com/zb/meeteat/domain/restaurant/repository/RestaurantRepository.java
@@ -11,32 +11,32 @@ import org.springframework.data.repository.query.Param;
 public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
 
   @Query(value = "SELECT r.id, r.kakaomaps_id, r.place_name, r.phone, r.y, r.x, r.road_address_name, "
-      + "r.category_name, r.rating, COALESCE(NULLIF(rr.img_url, ''), '') as thumbnail "
+      + "r.category_name, r.rating, COALESCE(MAX(NULLIF(rr.img_url, '')), '') as thumbnail "
       + "FROM Restaurant r LEFT JOIN RestaurantReview rr ON r.id = rr.restaurant_id "
       + "WHERE r.id = :restaurantId "
-      + "GROUP BY r.id ORDER BY rr.id DESC", nativeQuery = true)
+      + "GROUP BY r.id ORDER BY MAX(rr.id) DESC", nativeQuery = true)
   RestaurantResponse getRestaurantById(Long restaurantId);
 
   // 지역, 카테고리명, 장소명
   @Query(value = "SELECT r.id, r.kakaomaps_id, r.place_name, r.phone, r.y, r.x, r.road_address_name, "
-      + "r.category_name, r.rating, COALESCE(NULLIF(rr.img_url, ''), '') as thumbnail "
+      + "r.category_name, r.rating, COALESCE(MAX(NULLIF(rr.img_url, '')), '') as thumbnail "
       + "FROM Restaurant r LEFT JOIN RestaurantReview rr ON r.id = rr.restaurant_id "
       + "WHERE r.road_address_name LIKE %:region% "
       + "AND r.place_name LIKE %:placeName% "
       + "AND r.category_name LIKE %:categoryName% "
-      + "GROUP BY r.id ORDER BY rr.id DESC", nativeQuery = true)
+      + "GROUP BY r.id ORDER BY MAX(rr.id) DESC", nativeQuery = true)
   Page<RestaurantResponse> getRestaurantByRegionAndCategoryNameAndPlaceName(
       String region, String placeName, String categoryName, Pageable pageable);
 
   // 지역, 장소명, 카테고리명, 거리순-오름차순 정렬
   @Query(value = "SELECT r.id, r.kakaomaps_id, r.place_name, r.phone, r.y, r.x, r.road_address_name, "
-      + "r.category_name, r.rating, COALESCE(NULLIF(rr.img_url, ''), '') as thumbnail "
+      + "r.category_name, r.rating, COALESCE(MAX(NULLIF(rr.img_url, '')), '') as thumbnail "
       + "FROM Restaurant r LEFT JOIN RestaurantReview rr ON r.id = rr.restaurant_id "
       + "WHERE r.road_address_name LIKE %:region% "
       + "AND r.place_name LIKE %:placeName% "
       + "AND r.category_name LIKE %:categoryName% "
       + "GROUP BY r.id ORDER by "
-      + "(6371 * acos(cos(radians(:userLat)) * cos(radians(r.y)) * cos(radians(r.x) - radians(:userLon)) + sin(radians(:userLat)) * sin(radians(r.y)))) ASC, rr.id DESC"
+      + "(6371 * acos(cos(radians(:userLat)) * cos(radians(r.y)) * cos(radians(r.x) - radians(:userLon)) + sin(radians(:userLat)) * sin(radians(r.y)))) ASC, MAX(rr.id) DESC"
   , nativeQuery = true)
   Page<RestaurantResponse> getRestaurantByRegionAndPlaceNameAndCategoryNameOrderByDistance(
       @Param("userLat") double y,
@@ -48,7 +48,7 @@ public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
 
   // 지역, 장소명, 카테고리명, 평점순-내림차순 정렬
   @Query(value = "SELECT r.id, r.kakaomaps_id, r.place_name, r.phone, r.y, r.x, r.road_address_name, "
-      + "r.category_name, r.rating, COALESCE(NULLIF(rr.img_url, ''), '') as thumbnail "
+      + "r.category_name, r.rating, COALESCE(MAX(NULLIF(rr.img_url, '')), '') as thumbnail "
       + "FROM Restaurant r LEFT JOIN RestaurantReview rr ON r.id = rr.restaurant_id "
       + "WHERE r.road_address_name LIKE %:region% "
       + "AND r.place_name LIKE %:placeName% "

--- a/src/main/java/com/zb/meeteat/domain/restaurant/repository/RestaurantReviewRepository.java
+++ b/src/main/java/com/zb/meeteat/domain/restaurant/repository/RestaurantReviewRepository.java
@@ -1,5 +1,6 @@
 package com.zb.meeteat.domain.restaurant.repository;
 
+import com.zb.meeteat.domain.restaurant.dto.RestaurantReviewsResponse;
 import com.zb.meeteat.domain.restaurant.entity.RestaurantReview;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -9,8 +10,13 @@ import org.springframework.data.repository.query.Param;
 
 public interface RestaurantReviewRepository extends JpaRepository<RestaurantReview, Long> {
 
-  @Query("SELECT r FROM RestaurantReview r WHERE r.restaurant.id = :restaurantId")
-  Page<RestaurantReview> getRestaurantReviewByRestaurantId(
+  @Query(value = "SELECT r.id, r.rating, r.description, r.img_url as imgUrl, u.nickname, "
+      + "DATE_FORMAT(r.created_at, '%Y-%m-%d %H:%i:%s') AS created_at "
+      + "FROM RestaurantReview r "
+      + "JOIN user u ON r.user_id = u.id "
+      + "WHERE r.restaurant_id = :restaurantId ORDER BY r.id DESC"
+      , nativeQuery = true)
+  Page<RestaurantReviewsResponse> getRestaurantReviewByRestaurantId(
       @Param("restaurantId") Long restaurantId, Pageable pageable);
 
   RestaurantReview findRestaurantReviewByMatchingHistoryId(Long matchingHistoryId);

--- a/src/main/java/com/zb/meeteat/domain/restaurant/service/RestaurantService.java
+++ b/src/main/java/com/zb/meeteat/domain/restaurant/service/RestaurantService.java
@@ -6,6 +6,7 @@ import com.zb.meeteat.domain.matching.entity.MatchingStatus;
 import com.zb.meeteat.domain.matching.repository.MatchingHistoryRepository;
 import com.zb.meeteat.domain.restaurant.dto.CreateReviewRequest;
 import com.zb.meeteat.domain.restaurant.dto.RestaurantResponse;
+import com.zb.meeteat.domain.restaurant.dto.RestaurantReviewsResponse;
 import com.zb.meeteat.domain.restaurant.dto.SearchRequest;
 import com.zb.meeteat.domain.restaurant.entity.RestaurantReview;
 import com.zb.meeteat.domain.restaurant.repository.RestaurantRepository;
@@ -84,7 +85,7 @@ public class RestaurantService {
     return restaurantRepository.getRestaurantById(restaurantId);
   }
 
-  public Page<RestaurantReview> getRestaurantReviews(
+  public Page<RestaurantReviewsResponse> getRestaurantReviews(
       Long restaurantId, int page, int size) {
 
     // Pageable 객체 생성 (페이지, 사이즈, 정렬 방식)


### PR DESCRIPTION
### Pull Request
> ### 변경사항
> 📌 **AS-IS**
- 식당 조회 시 thumbnail 이미지 리뷰의 최초 이미지를 가져옴.
- 식당 조회 시, 식당에 리뷰가 없는 경우 오류가 발생.
- 식당 리뷰 조회 시 조인 테이블 데이터까지 모두 출력.

> 🔖 **TO-BE**
- 식당 상세 조회 Page<RestaurantReview> -> Page<RestaurantReviewsResponse>로 DTO 변경
  - 기존에 RestaurantReview 엔티티를 사용해 식당 상세 정보를 조회하던 방식에서, RestaurantReviewsResponse DTO를 사용하여 필요한 데이터만 추출하여 응답함.
  - 리뷰가 없는 경우에도 "" 빈값의 thumnail을 보내도록 수정
  - 최신리뷰의 이미지 thumnail을 가지고 옴.
- 리뷰 조회 시 개선 사항:
  - 조인 테이블에서 restaurant와 user 데이터를 모두 가져오는 대신, RestaurantReviewsResponse에 필요한 데이터만 추출하여 최적화.
- 기타 리팩토링:
  - Restaurant Entity의 필드 타입을 Wrapper 타입으로 변경하여 null 값을 허용하고, camelCase로 필드명을 변경하여 코드 스타일을 일관성 있게 유지.