### PR TITLE
Feat: 회원 탈퇴 기능 구현

### DIFF
--- a/src/main/java/com/zb/meeteat/domain/matching/repository/MatchingHistoryRepository.java
+++ b/src/main/java/com/zb/meeteat/domain/matching/repository/MatchingHistoryRepository.java
@@ -1,8 +1,10 @@
 package com.zb.meeteat.domain.matching.repository;
 
 import com.zb.meeteat.domain.matching.entity.MatchingHistory;
+import com.zb.meeteat.domain.matching.entity.MatchingStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MatchingHistoryRepository extends JpaRepository<MatchingHistory, Long> {
 
+  boolean existsByUserIdAndStatus(Long userId, MatchingStatus status);
 }

--- a/src/main/java/com/zb/meeteat/domain/user/controller/AuthController.java
+++ b/src/main/java/com/zb/meeteat/domain/user/controller/AuthController.java
@@ -17,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -73,6 +74,18 @@ public class AuthController {
   public ResponseEntity<Void> signout(@RequestHeader("Authorization") String token) {
     authService.signout(token);
     return ResponseEntity.ok().build();
+  }
+
+  // 회원 탈퇴
+  @DeleteMapping("/withdrawal")
+  public ResponseEntity<String> withdrawUser(
+      @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    log.info("회원 탈퇴 요청: {}", userDetails.getUsername());
+
+    userService.withdrawUser(userDetails.getUser());
+
+    return ResponseEntity.ok("회원 탈퇴가 완료되었습니다.");
+
   }
 
   // 비밀번호 변경

--- a/src/main/java/com/zb/meeteat/domain/user/service/UserService.java
+++ b/src/main/java/com/zb/meeteat/domain/user/service/UserService.java
@@ -1,19 +1,24 @@
 package com.zb.meeteat.domain.user.service;
 
+import com.zb.meeteat.domain.matching.entity.MatchingStatus;
+import com.zb.meeteat.domain.matching.repository.MatchingHistoryRepository;
 import com.zb.meeteat.domain.user.dto.UserProfileResponse;
 import com.zb.meeteat.domain.user.entity.User;
 import com.zb.meeteat.domain.user.repository.UserRepository;
 import com.zb.meeteat.exception.CustomException;
 import com.zb.meeteat.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserService {
 
   private final UserRepository userRepository;
+  private final MatchingHistoryRepository matchingHistoryRepository;
 
   @Transactional
   public UserProfileResponse getUserProfile(Long userId) {
@@ -51,6 +56,21 @@ public class UserService {
   public void updateIntroduce(User user, String newIntroduce) {
     user.updateIntroduce(newIntroduce);
     userRepository.save(user);
+  }
+
+  @Transactional
+  public void withdrawUser(User user) {
+    // 현재 진행 중인 매칭 확인
+    boolean hasOngoingMatching = matchingHistoryRepository.existsByUserIdAndStatus(user.getId(),
+        MatchingStatus.MATCHED);
+
+    if (hasOngoingMatching) {
+      throw new CustomException(ErrorCode.USER_HAS_ONGOING_MATCHING);
+    }
+
+    // 유저 상태를 탈퇴 처리
+    userRepository.delete(user);
+    log.info("회원 탈퇴 처리 완료: {}", user.getEmail());
   }
 
 

--- a/src/main/java/com/zb/meeteat/exception/ErrorCode.java
+++ b/src/main/java/com/zb/meeteat/exception/ErrorCode.java
@@ -14,7 +14,7 @@ public enum ErrorCode {
   NICKNAME_ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "NICKNAME_ALREADY_REGISTERED", "이미 사용 중인 닉네임입니다."),
   USER_SCHEDULED_FOR_DELETION(HttpStatus.FORBIDDEN, "USER_SCHEDULED_FOR_DELETION", "해당 계정은 탈퇴 예정 상태입니다."),
   SAME_PASSWORD(HttpStatus.BAD_REQUEST, "SAME_PASSWORD", "현재 비밀번호와 동일한 비밀번호로 변경할 수 없습니다."),
-  USER_CANNOT_BE_DELETED_DUE_TO_MATCHING(HttpStatus.BAD_REQUEST, "USER_CANNOT_BE_DELETED_DUE_TO_MATCHING", " 현재 매칭 진행 중이므로 탈퇴할 수 없습니다."),
+  USER_HAS_ONGOING_MATCHING(HttpStatus.BAD_REQUEST, "USER_HAS_ONGOING_MATCHING", "현재 진행 중인 매칭이 있어 탈퇴할 수 없습니다."),
   PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "PASSWORD_MISMATCH", "현재 비밀번호가 일치하지 않습니다."),
   INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "INVALID_PASSWORD", "비밀번호는 최소 8자 이상이며, 영문, 숫자, 특수문자를 각각 하나 이상 포함해야 합니다."),
   INVALID_TOKEN(HttpStatus.BAD_REQUEST, "INVALID_TOKEN", "유효하지 않은 토큰입니다."),


### PR DESCRIPTION
### Pull Request

> ### 변경사항
> 
> 📌 **AS-IS**
> - 회원 탈퇴 기능 미구현
> - 회원 탈퇴 시 매칭 상태를 고려하지 않음
> - 진행 중인 매칭이 있는 사용자도 탈퇴 가능

> 🔖 **TO-BE**
> - 회원 탈퇴 API (`DELETE /api/users/withdrawal`) 추가
> - 회원 탈퇴 시 진행 중인 매칭 여부 확인
> - 진행 중인 매칭(`MATCHED` 상태)이 있는 경우 탈퇴 불가 처리
> - `MatchingHistoryRepository`를 이용하여 사용자 매칭 상태 조회
> - `ErrorCode`에 `USER_HAS_ONGOING_MATCHING` 예외 코드 추가

> ### 테스트
>
> - [ ] API 테스트 진행
> - [ ] 진행 중인 매칭이 없는 경우 정상 탈퇴 확인
