### PR TITLE
refactor(config): 식당 검색 api 인증 필요 없도록 변경

### DIFF
--- a/src/main/java/com/zb/meeteat/config/SecurityConfig.java
+++ b/src/main/java/com/zb/meeteat/config/SecurityConfig.java
@@ -43,7 +43,7 @@ public class SecurityConfig {
             session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .authorizeHttpRequests(authorize -> authorize
             .requestMatchers(HttpMethod.POST, "/api/users/signup", "/api/users/signin",
-                "/api/users/signin/*").permitAll()
+                "/api/users/signin/*", "api/restaurants/search", "api/restaurants/*").permitAll()
             .requestMatchers(HttpMethod.POST, "/api/users/change-password").authenticated() // 인증 필요
             .anyRequest().authenticated()
         )


### PR DESCRIPTION
### Pull Request

> ### 변경사항
> 
> **AS-IS**  
> - 기존에는 `/api/restaurants/search` 및 `/api/restaurants/*` 엔드포인트에 대한 접근 제한이 설정되어 있었음.  
>   
> **TO-BE**  
> - `/api/restaurants/search`, `/api/restaurants/*` 엔드포인트를 `permitAll()`로 변경하여 인증 없이 접근 가능하도록 수정.  

> ### 테스트
> 
> - [ ] 테스트 코드  
> - [ ] API 테스트 (비로그인 상태에서 `/api/restaurants/search` 및 `/api/restaurants/{id}` 엔드포인트 호출 확인)  
