### PR TITLE
Feat(auth): 첫 로그인 시에만 needProfileUpdate 반환하도록 수정

### DIFF
--- a/src/main/java/com/zb/meeteat/domain/user/dto/AuthCodeResponseDto.java
+++ b/src/main/java/com/zb/meeteat/domain/user/dto/AuthCodeResponseDto.java
@@ -1,13 +1,26 @@
 package com.zb.meeteat.domain.user.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class AuthCodeResponseDto {
 
-  private String accessToken;
-  private boolean needProfileUpdate;
+  private final String accessToken;
+  private final Boolean needProfileUpdate;
+
+  // 첫 로그인 시 사용하는 생성자
+  public AuthCodeResponseDto(String accessToken, boolean needProfileUpdate) {
+    this.accessToken = accessToken;
+    this.needProfileUpdate = needProfileUpdate;
+  }
+
+  // 이후 로그인 시 사용하는 생성자
+  public AuthCodeResponseDto(String accessToken) {
+    this.accessToken = accessToken;
+    this.needProfileUpdate = null;
+  }
 
 }

--- a/src/main/java/com/zb/meeteat/domain/user/service/UserService.java
+++ b/src/main/java/com/zb/meeteat/domain/user/service/UserService.java
@@ -9,6 +9,7 @@ import com.zb.meeteat.exception.CustomException;
 import com.zb.meeteat.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +20,7 @@ public class UserService {
 
   private final UserRepository userRepository;
   private final MatchingHistoryRepository matchingHistoryRepository;
+  private final RedisTemplate<String, String> redisTemplate;
 
   @Transactional
   public UserProfileResponse getUserProfile(Long userId) {
@@ -67,6 +69,11 @@ public class UserService {
     if (hasOngoingMatching) {
       throw new CustomException(ErrorCode.USER_HAS_ONGOING_MATCHING);
     }
+
+    // Redis에서 firstLogin 데이터 삭제
+    String redisKey = "firstLogin:" + user.getId();
+    redisTemplate.delete(redisKey);
+    log.info("Redis에서 firstLogin 데이터 삭제 완료: {}", redisKey);
 
     // 유저 상태를 탈퇴 처리
     userRepository.delete(user);


### PR DESCRIPTION
### **Pull Request**

> ### **변경사항**  
>  
> 📌 **AS-IS**  
> - 로그인 시 항상 `needProfileUpdate` 필드를 응답  
> - 첫 로그인 여부와 관계없이 `needProfileUpdate: false`가 반환되는 경우가 있음  
>  
> 🔖 **TO-BE**  
> - 첫 로그인 시에만 `needProfileUpdate: true` 반환  
> - 이후 로그인부터는 `needProfileUpdate` 필드를 **아예 응답에서 제외**  
> - Redis에 `firstLogin:userId` 키를 저장하여 **첫 로그인 여부를 판단**  
> - `AuthCodeResponseDto`에 `@JsonInclude(JsonInclude.Include.NON_NULL)` 추가하여 `null` 값은 응답에서 자동 제거  
> - 회원 탈퇴시 Redis에 저장된 `firstLogin:userId()` 값 삭제

---

> ### **테스트**  
>  
> - [x] **첫 로그인 시** `needProfileUpdate: true` 반환 확인**
> - [x] **두 번째 로그인 이후** `needProfileUpdate` 필드가 응답에서 제거되는지 확인**
> - [x] **Redis에 첫 로그인 여부(`firstLogin:userId`)가 정상적으로 저장되는지 확인**  
> - [x] **회원 탈퇴시 Redis에 저장된 firstLogin:userId`값이 정상적으로 삭제되는지 확인**  
> - [x] **API 테스트 진행 및 응답 확인**  