### PR TITLE
Restaurant

### DIFF
--- a/src/main/java/com/zb/meeteat/config/SecurityConfig.java
+++ b/src/main/java/com/zb/meeteat/config/SecurityConfig.java
@@ -43,7 +43,8 @@ public class SecurityConfig {
             session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .authorizeHttpRequests(authorize -> authorize
             .requestMatchers(HttpMethod.POST, "/api/users/signup", "/api/users/signin",
-                "/api/users/signin/*", "api/restaurants/search", "api/restaurants/*").permitAll()
+                "/api/users/signin/*", "api/restaurants/search", "api/restaurants/{restaurantId}").permitAll()
+            .requestMatchers(HttpMethod.GET, "/api/restaurants/{restaurantId}", "/api/restaurants/{restaurantId}/reviews").permitAll()
             .requestMatchers(HttpMethod.POST, "/api/users/change-password").authenticated() // 인증 필요
             .anyRequest().authenticated()
         )

--- a/src/main/java/com/zb/meeteat/domain/restaurant/controller/RestaurantController.java
+++ b/src/main/java/com/zb/meeteat/domain/restaurant/controller/RestaurantController.java
@@ -1,6 +1,7 @@
 package com.zb.meeteat.domain.restaurant.controller;
 
 import com.zb.meeteat.domain.restaurant.dto.CreateReviewRequest;
+import com.zb.meeteat.domain.restaurant.dto.RestaurantMyReviewResponse;
 import com.zb.meeteat.domain.restaurant.dto.RestaurantResponse;
 import com.zb.meeteat.domain.restaurant.dto.RestaurantReviewsResponse;
 import com.zb.meeteat.domain.restaurant.dto.SearchRequest;
@@ -72,13 +73,13 @@ public class RestaurantController {
 
   // 나의 식당 후기 조회
   @GetMapping("/myreview")
-  public ResponseEntity<RestaurantReview> getMyReview(
+  public ResponseEntity<RestaurantMyReviewResponse> getMyReview(
       @RequestHeader("Authorization") String token,
       @RequestParam(value = "matchingHistoryId", required = true) String matchingHistoryId
   ) {
 
-    jwtUtil.validateToken(token);
+    Long userId = jwtUtil.getUserId(token.replace("Bearer ", ""));
     return ResponseEntity.ok(
-        restaurantService.getMyReviewByMatching(Long.parseLong(matchingHistoryId)));
+        restaurantService.getMyReviewByMatching(Long.parseLong(matchingHistoryId), userId));
   }
 }

--- a/src/main/java/com/zb/meeteat/domain/restaurant/controller/RestaurantController.java
+++ b/src/main/java/com/zb/meeteat/domain/restaurant/controller/RestaurantController.java
@@ -64,10 +64,9 @@ public class RestaurantController {
   public ResponseEntity createReview(
       @RequestHeader("Authorization") String token,
       @ModelAttribute @Valid CreateReviewRequest req) throws CustomException {
-    // 토큰에서 userId 추출
-    long userId = jwtUtil.getUserId(token.replace("Bearer ", "")); // "Bearer "를 제거하고 토큰을 전달
+    long userId = jwtUtil.getUserId(token.replace("Bearer ", ""));
 
-    RestaurantReview review = restaurantService.createReview(userId, req);
+    restaurantService.createReview(userId, req);
     return ResponseEntity.ok().build();
   }
 

--- a/src/main/java/com/zb/meeteat/domain/restaurant/dto/RestaurantMyReviewResponse.java
+++ b/src/main/java/com/zb/meeteat/domain/restaurant/dto/RestaurantMyReviewResponse.java
@@ -1,0 +1,22 @@
+package com.zb.meeteat.domain.restaurant.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL) // null 값을 가진 필드는 JSON에서 제외
+public class RestaurantMyReviewResponse {
+  private Long id;
+  private Integer rating;
+  private String description;
+  private String imageUrl;
+  private String nickName;
+  private LocalDateTime createdAt;
+}

--- a/src/main/java/com/zb/meeteat/domain/restaurant/dto/RestaurantResponse.java
+++ b/src/main/java/com/zb/meeteat/domain/restaurant/dto/RestaurantResponse.java
@@ -1,6 +1,7 @@
 package com.zb.meeteat.domain.restaurant.dto;
 
 
+import com.zb.meeteat.domain.restaurant.entity.Restaurant;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,19 +10,31 @@ import lombok.Setter;
 
 @Getter
 @Setter
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
 public class RestaurantResponse {
 
-  private Long id;
+  private Long restaurantId;
   private Long kakaomaps_id;
   private String place_name;
   private String phone;
-  private double y;
   private double x;
+  private double y;
   private String road_address_name;
   private String category_name;
   private double rating;
   private String thumbnail;
+
+  public static RestaurantResponse fromRestaurant(Restaurant restaurant, String thumbnail) {
+    RestaurantResponse res = new RestaurantResponse();
+    res.setRestaurantId(restaurant.getId());
+    res.setKakaomaps_id(restaurant.getKakaomapsId());
+    res.setPlace_name(restaurant.getPlaceName());
+    res.setPhone(restaurant.getPhone());
+    res.setX(restaurant.getX());
+    res.setY(restaurant.getY());
+    res.setRoad_address_name(restaurant.getRoadAddressName());
+    res.setCategory_name(restaurant.getCategoryName());
+    res.setRating(restaurant.getRating());
+    res.setThumbnail(thumbnail);
+    return res;
+  }
 }

--- a/src/main/java/com/zb/meeteat/domain/restaurant/dto/SearchRequest.java
+++ b/src/main/java/com/zb/meeteat/domain/restaurant/dto/SearchRequest.java
@@ -31,7 +31,7 @@ public class SearchRequest {
   private double userX;
 
   @NotNull(message = "유효하지 않은 정렬입니다.")
-  private Sort sort; // RATING : 평점순(내림차순), DISTANCE: 거리순(오름차순)
+  private Sort sorted; // RATING : 평점순(내림차순), DISTANCE: 거리순(오름차순)
 
   @Min(value = 0, message = "페이지는 0이상 가능합니다")
   private int page;

--- a/src/main/java/com/zb/meeteat/domain/restaurant/entity/RestaurantReview.java
+++ b/src/main/java/com/zb/meeteat/domain/restaurant/entity/RestaurantReview.java
@@ -3,6 +3,7 @@ package com.zb.meeteat.domain.restaurant.entity;
 import com.zb.meeteat.domain.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -51,7 +52,7 @@ public class RestaurantReview {
   @JoinColumn(name = "user_id")
   private User user;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "restaurant_id")
   private Restaurant restaurant;
 

--- a/src/main/java/com/zb/meeteat/domain/restaurant/repository/RestaurantReviewRepository.java
+++ b/src/main/java/com/zb/meeteat/domain/restaurant/repository/RestaurantReviewRepository.java
@@ -3,6 +3,7 @@ package com.zb.meeteat.domain.restaurant.repository;
 import com.zb.meeteat.domain.restaurant.dto.RestaurantReviewsResponse;
 import com.zb.meeteat.domain.restaurant.entity.Restaurant;
 import com.zb.meeteat.domain.restaurant.entity.RestaurantReview;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -25,4 +26,6 @@ public interface RestaurantReviewRepository extends JpaRepository<RestaurantRevi
   RestaurantReview findRestaurantReviewByMatchingHistoryId(Long matchingHistoryId);
 
   RestaurantReview findTop1ByRestaurantOrderByImgUrlDesc(Restaurant restaurant);
+
+  List<RestaurantReview> findAllByRestaurant(Restaurant restaurant);
 }

--- a/src/main/java/com/zb/meeteat/domain/restaurant/repository/RestaurantReviewRepository.java
+++ b/src/main/java/com/zb/meeteat/domain/restaurant/repository/RestaurantReviewRepository.java
@@ -1,13 +1,16 @@
 package com.zb.meeteat.domain.restaurant.repository;
 
 import com.zb.meeteat.domain.restaurant.dto.RestaurantReviewsResponse;
+import com.zb.meeteat.domain.restaurant.entity.Restaurant;
 import com.zb.meeteat.domain.restaurant.entity.RestaurantReview;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface RestaurantReviewRepository extends JpaRepository<RestaurantReview, Long> {
 
   @Query(value = "SELECT r.id, r.rating, r.description, r.img_url as imgUrl, u.nickname, "
@@ -20,4 +23,6 @@ public interface RestaurantReviewRepository extends JpaRepository<RestaurantRevi
       @Param("restaurantId") Long restaurantId, Pageable pageable);
 
   RestaurantReview findRestaurantReviewByMatchingHistoryId(Long matchingHistoryId);
+
+  RestaurantReview findTop1ByRestaurantOrderByImgUrlDesc(Restaurant restaurant);
 }

--- a/src/main/java/com/zb/meeteat/domain/restaurant/service/RestaurantService.java
+++ b/src/main/java/com/zb/meeteat/domain/restaurant/service/RestaurantService.java
@@ -54,13 +54,13 @@ public class RestaurantService {
     Page<RestaurantResponse> restaurants = Page.empty();
 
 
-    if (Sort.RATING.equals(search.getSorted())) {
+    if (Sort.RATING.equals(search.getSort())) {
       restaurants = restaurantRepository.getRestaurantByRegionAndPlaceNameAndCategoryNameOrderByRatingDesc(
           search.getRegion().toString(),
           search.getPlaceName(),
           categoryName,
           pageable);
-    } else if (Sort.DISTANCE.equals(search.getSorted())) {
+    } else if (Sort.DISTANCE.equals(search.getSort())) {
       if (Double.isNaN(search.getUserX()) || Double.isNaN(search.getUserX())) {
         throw new CustomException(ErrorCode.USER_LOCATION_NOT_PROVIDED);
       }


### PR DESCRIPTION
### Pull Request
> ### 변경사항
> 📌 **AS-IS**
- 식당 상세조회/리뷰 API 접근 POST 허용
- 식당 상세조회 반환값 Entity
- 식당 평점 계산 누락
- 후기를 조회하는 API에서 `RestaurantReview` Entity 반환

> 🔖 **TO-BE**
- SecurityConfig에서 Post -> Get으로 수정되었습니다.
  - `.requestMatchers(HttpMethod.GET, "/api/restaurants/{restaurantId}", "/api/restaurants/{restaurantId}/reviews").permitAll()`
- `getRestaurant` 메서드를 수정하여 `RestaurantResponse` DTO를 반환하도록 변경
  - 최신 리뷰이미지를 반환하는 쿼리를 NativeQuery 대신  JPA의 메서드 쿼리 방식으로 수정
  - `RestaurantReview findTop1ByRestaurantOrderByImgUrlDesc(Restaurant restaurant);`
- 식당 리뷰를 작성한 후 식당의 평점을 업데이트 기능이 추가되었습니다.
- RestaurantReview` 엔티티의 `restaurant` 필드에서 `fetch = FetchType.LAZY` 추가하여 성능 최적화.
- 후기를 조회하는 API에서 `RestaurantReview` 엔티티 대신 `RestaurantMyReviewResponse` DTO를 반환하도록 수정하여 불필요한 조인된 테이블 데이터를 제외하였습니다.