### PR TITLE
refactor: 식당 조회 및 리뷰 조회 querydsl로 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,12 +41,19 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-hateoas"
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
+    //QueryDsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     implementation 'com.mysql:mysql-connector-j'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/zb/meeteat/config/QueryDslConfig.java
+++ b/src/main/java/com/zb/meeteat/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.zb.meeteat.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+  @PersistenceContext
+  private EntityManager entityManager;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(entityManager);
+  }
+}

--- a/src/main/java/com/zb/meeteat/domain/restaurant/repository/RestaurantRepository.java
+++ b/src/main/java/com/zb/meeteat/domain/restaurant/repository/RestaurantRepository.java
@@ -1,62 +1,8 @@
 package com.zb.meeteat.domain.restaurant.repository;
 
-import com.zb.meeteat.domain.restaurant.dto.RestaurantResponse;
 import com.zb.meeteat.domain.restaurant.entity.Restaurant;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
+public interface RestaurantRepository extends JpaRepository<Restaurant, Long>, RestaurantRepositoryCustom {
 
-  @Query(value = "SELECT r.id, r.kakaomaps_id, r.place_name, r.phone, r.y, r.x, r.road_address_name, "
-      + "r.category_name, r.rating, COALESCE(MAX(NULLIF(rr.img_url, '')), '') as thumbnail "
-      + "FROM Restaurant r LEFT JOIN RestaurantReview rr ON r.id = rr.restaurant_id "
-      + "WHERE r.id = :restaurantId "
-      + "GROUP BY r.id ORDER BY MAX(rr.id) DESC", nativeQuery = true)
-  RestaurantResponse getRestaurantById(Long restaurantId);
-
-  // 지역, 카테고리명, 장소명
-  @Query(value = "SELECT r.id, r.kakaomaps_id, r.place_name, r.phone, r.y, r.x, r.road_address_name, "
-      + "r.category_name, r.rating, COALESCE(MAX(NULLIF(rr.img_url, '')), '') as thumbnail "
-      + "FROM Restaurant r LEFT JOIN RestaurantReview rr ON r.id = rr.restaurant_id "
-      + "WHERE r.road_address_name LIKE %:region% "
-      + "AND r.place_name LIKE %:placeName% "
-      + "AND r.category_name LIKE %:categoryName% "
-      + "GROUP BY r.id ORDER BY MAX(rr.id) DESC", nativeQuery = true)
-  Page<RestaurantResponse> getRestaurantByRegionAndCategoryNameAndPlaceName(
-      String region, String placeName, String categoryName, Pageable pageable);
-
-  // 지역, 장소명, 카테고리명, 거리순-오름차순 정렬
-  @Query(value = "SELECT r.id, r.kakaomaps_id, r.place_name, r.phone, r.y, r.x, r.road_address_name, "
-      + "r.category_name, r.rating, COALESCE(MAX(NULLIF(rr.img_url, '')), '') as thumbnail "
-      + "FROM Restaurant r LEFT JOIN RestaurantReview rr ON r.id = rr.restaurant_id "
-      + "WHERE r.road_address_name LIKE %:region% "
-      + "AND r.place_name LIKE %:placeName% "
-      + "AND r.category_name LIKE %:categoryName% "
-      + "GROUP BY r.id ORDER by "
-      + "(6371 * acos(cos(radians(:userLat)) * cos(radians(r.y)) * cos(radians(r.x) - radians(:userLon)) + sin(radians(:userLat)) * sin(radians(r.y)))) ASC, MAX(rr.id) DESC"
-  , nativeQuery = true)
-  Page<RestaurantResponse> getRestaurantByRegionAndPlaceNameAndCategoryNameOrderByDistance(
-      @Param("userLat") double y,
-      @Param("userLon") double x,
-      @Param("region") String region,
-      @Param("placeName") String placeName,
-      @Param("categoryName") String categoryName,
-      Pageable pageable);
-
-  // 지역, 장소명, 카테고리명, 평점순-내림차순 정렬
-  @Query(value = "SELECT r.id, r.kakaomaps_id, r.place_name, r.phone, r.y, r.x, r.road_address_name, "
-      + "r.category_name, r.rating, COALESCE(MAX(NULLIF(rr.img_url, '')), '') as thumbnail "
-      + "FROM Restaurant r LEFT JOIN RestaurantReview rr ON r.id = rr.restaurant_id "
-      + "WHERE r.road_address_name LIKE %:region% "
-      + "AND r.place_name LIKE %:placeName% "
-      + "AND r.category_name LIKE %:categoryName% "
-      + "GROUP BY r.id ORDER by r.rating DESC", nativeQuery = true)
-  Page<RestaurantResponse> getRestaurantByRegionAndPlaceNameAndCategoryNameOrderByRatingDesc(
-      @Param("region") String region,
-      @Param("placeName") String placeName,
-      @Param("categoryName") String categoryName,
-      Pageable pageable);
 }

--- a/src/main/java/com/zb/meeteat/domain/restaurant/repository/RestaurantRepositoryCustom.java
+++ b/src/main/java/com/zb/meeteat/domain/restaurant/repository/RestaurantRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.zb.meeteat.domain.restaurant.repository;
+
+import com.zb.meeteat.domain.restaurant.dto.RestaurantResponse;
+import com.zb.meeteat.domain.restaurant.dto.SearchRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface RestaurantRepositoryCustom {
+  Page<RestaurantResponse> findRestaurantsByFilters(SearchRequest searchRequest, Pageable pageable);
+}

--- a/src/main/java/com/zb/meeteat/domain/restaurant/repository/RestaurantRepositoryCustomImpl.java
+++ b/src/main/java/com/zb/meeteat/domain/restaurant/repository/RestaurantRepositoryCustomImpl.java
@@ -1,0 +1,90 @@
+package com.zb.meeteat.domain.restaurant.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberTemplate;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.zb.meeteat.domain.restaurant.dto.RestaurantResponse;
+import com.zb.meeteat.domain.restaurant.dto.SearchRequest;
+import com.zb.meeteat.domain.restaurant.dto.Sort;
+import com.zb.meeteat.domain.restaurant.entity.QRestaurant;
+import com.zb.meeteat.domain.restaurant.entity.QRestaurantReview;
+import com.zb.meeteat.domain.restaurant.entity.Restaurant;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class RestaurantRepositoryCustomImpl implements RestaurantRepositoryCustom {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public Page<RestaurantResponse> findRestaurantsByFilters(
+      SearchRequest searchRequest, Pageable pageable) {
+
+    QRestaurant restaurant = QRestaurant.restaurant;
+    QRestaurantReview restaurantReview = QRestaurantReview.restaurantReview;
+
+    BooleanBuilder builder = new BooleanBuilder();
+    builder.and(restaurant.roadAddressName.contains(String.valueOf(searchRequest.getRegion())));
+    builder.and(restaurant.categoryName.contains(String.valueOf(searchRequest.getCategoryName())));
+    builder.and(restaurant.placeName.contains(searchRequest.getPlaceName()));
+
+    JPAQuery<Restaurant> jpaQuery = queryFactory.select(restaurant)
+        .from(restaurant)
+        .leftJoin(restaurantReview).on(restaurant.id.eq(restaurantReview.restaurant.id))
+        .where(builder)
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize());
+
+    // 필터링 및 정렬 처리
+    if (searchRequest.getSorted() == Sort.RATING) {
+      jpaQuery = jpaQuery.orderBy(restaurant.rating.desc());
+    } else if (searchRequest.getSorted() == Sort.DISTANCE) {
+      jpaQuery = applyDistanceSort(jpaQuery, searchRequest, restaurant);
+    }
+
+    List<Restaurant> result = jpaQuery.fetch();
+    long total = Optional.ofNullable(queryFactory.select(restaurant.count())
+            .from(restaurant)
+            .leftJoin(restaurantReview).on(restaurant.id.eq(restaurantReview.restaurant.id))
+            .where(builder)
+            .fetchOne())
+        .orElse(0L);
+
+    List<RestaurantResponse> responseList = result.stream()
+        .map(r -> RestaurantResponse.fromRestaurant(r, getLatestThumbnail(r)))  // 여기에서 getLatestThumbnail을 Restaurant 객체로 수정
+        .toList();
+
+    return new PageImpl<>(responseList, pageable, total);
+  }
+
+  private JPAQuery<Restaurant> applyDistanceSort(JPAQuery<Restaurant> query, SearchRequest searchRequest, QRestaurant restaurant) {
+    // Haversine 공식으로 거리 계산
+    NumberTemplate<Double> distanceExpression = Expressions.numberTemplate(
+        Double.class,
+        "6371 * acos(cos(radians({0})) * cos(radians({1})) * cos(radians({2}) - radians({3})) + sin(radians({0})) * sin(radians({1})))",
+        searchRequest.getUserY(), restaurant.y, restaurant.x, searchRequest.getUserX()
+    );
+    return query.orderBy(distanceExpression.asc());
+  }
+
+  private String getLatestThumbnail(Restaurant restaurant) {
+    QRestaurantReview restaurantReview = QRestaurantReview.restaurantReview;
+
+    // 최신 리뷰의 이미지를 가져오는 쿼리
+    return queryFactory.select(restaurantReview.imgUrl)
+        .from(restaurantReview)
+        .where(restaurantReview.restaurant.id.eq(restaurant.getId()))
+        .orderBy(restaurantReview.imgUrl.desc())  // 최신 리뷰 이미지가 먼저 오도록 정렬
+        .limit(1)  // 한 개만 가져오기
+        .fetchFirst();  // 첫 번째 결과 반환
+  }
+}

--- a/src/main/java/com/zb/meeteat/domain/restaurant/repository/RestaurantReviewRepository.java
+++ b/src/main/java/com/zb/meeteat/domain/restaurant/repository/RestaurantReviewRepository.java
@@ -12,16 +12,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface RestaurantReviewRepository extends JpaRepository<RestaurantReview, Long> {
-
-  @Query(value = "SELECT r.id, r.rating, r.description, r.img_url as imgUrl, u.nickname, "
-      + "DATE_FORMAT(r.created_at, '%Y-%m-%d %H:%i:%s') AS created_at "
-      + "FROM RestaurantReview r "
-      + "JOIN user u ON r.user_id = u.id "
-      + "WHERE r.restaurant_id = :restaurantId ORDER BY r.id DESC"
-      , nativeQuery = true)
-  Page<RestaurantReviewsResponse> getRestaurantReviewByRestaurantId(
-      @Param("restaurantId") Long restaurantId, Pageable pageable);
+public interface RestaurantReviewRepository extends JpaRepository<RestaurantReview, Long>, RestaurantReviewRepositoryCustom {
 
   RestaurantReview findRestaurantReviewByMatchingHistoryId(Long matchingHistoryId);
 

--- a/src/main/java/com/zb/meeteat/domain/restaurant/repository/RestaurantReviewRepositoryCustom.java
+++ b/src/main/java/com/zb/meeteat/domain/restaurant/repository/RestaurantReviewRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.zb.meeteat.domain.restaurant.repository;
+
+import com.zb.meeteat.domain.restaurant.dto.RestaurantReviewsResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface RestaurantReviewRepositoryCustom {
+  Page<RestaurantReviewsResponse> findRestaurantReviewsByRestaurantId(Long restaurantId, Pageable pageable);
+}

--- a/src/main/java/com/zb/meeteat/domain/restaurant/repository/RestaurantReviewRepositoryCustomImpl.java
+++ b/src/main/java/com/zb/meeteat/domain/restaurant/repository/RestaurantReviewRepositoryCustomImpl.java
@@ -1,0 +1,73 @@
+package com.zb.meeteat.domain.restaurant.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberTemplate;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.zb.meeteat.domain.restaurant.dto.RestaurantResponse;
+import com.zb.meeteat.domain.restaurant.dto.RestaurantReviewsResponse;
+import com.zb.meeteat.domain.restaurant.dto.SearchRequest;
+import com.zb.meeteat.domain.restaurant.dto.Sort;
+import com.zb.meeteat.domain.restaurant.entity.QRestaurant;
+import com.zb.meeteat.domain.restaurant.entity.QRestaurantReview;
+import com.zb.meeteat.domain.restaurant.entity.Restaurant;
+import com.zb.meeteat.domain.restaurant.entity.RestaurantReview;
+import com.zb.meeteat.domain.user.entity.QUser;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class RestaurantReviewRepositoryCustomImpl implements RestaurantReviewRepositoryCustom {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public Page<RestaurantReviewsResponse> findRestaurantReviewsByRestaurantId(Long restaurantId, Pageable pageable) {
+    QRestaurantReview restaurantReview = QRestaurantReview.restaurantReview;
+    QUser user = QUser.user;
+
+    BooleanBuilder builder = new BooleanBuilder();
+    builder.and(restaurantReview.restaurant.id.eq(restaurantId));
+
+    // 기본 쿼리
+    JPAQuery<RestaurantReview> query = queryFactory.selectFrom(restaurantReview)
+        .join(restaurantReview.user, user)  // 사용자와의 조인
+        .where(builder)
+        .orderBy(restaurantReview.createdAt.desc())
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize());
+
+    // 결과 페칭
+    List<RestaurantReview> result = query.fetch();
+
+    // 전체 리뷰의 수를 구하기 위한 쿼리
+    long total = Optional.ofNullable(queryFactory.select(restaurantReview.count())
+        .from(restaurantReview)
+        .where(builder)
+        .fetchOne())
+        .orElse(0L);
+
+    // RestaurantReviewResponse 변환
+    List<RestaurantReviewsResponse> responseList = result.stream()
+        .map(r -> new RestaurantReviewsResponse(
+            r.getId(),
+            r.getRating(),
+            r.getDescription(),
+            r.getImgUrl(),
+            r.getUser().getNickname(),
+            r.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+        ))
+        .collect(Collectors.toList());
+
+    return new PageImpl<>(responseList, pageable, total);
+  }
+}

--- a/src/main/java/com/zb/meeteat/domain/restaurant/service/RestaurantService.java
+++ b/src/main/java/com/zb/meeteat/domain/restaurant/service/RestaurantService.java
@@ -53,36 +53,14 @@ public class RestaurantService {
     // Pageable 객체 생성 (페이지, 사이즈, 정렬 방식)
     Pageable pageable = PageRequest.of(search.getPage(), search.getSize());
 
-    // 정렬 기준에 따라 쿼리 메소드 실행
-    Page<RestaurantResponse> restaurants = Page.empty();
-
-    if (Sort.RATING.equals(search.getSorted())) {
-      restaurants = restaurantRepository.getRestaurantByRegionAndPlaceNameAndCategoryNameOrderByRatingDesc(
-          search.getRegion().toString(),
-          search.getPlaceName(),
-          categoryName,
-          pageable);
-    } else if (Sort.DISTANCE.equals(search.getSorted())) {
+    if (Sort.DISTANCE.equals(search.getSorted())) {
       if (Double.isNaN(search.getUserX()) || Double.isNaN(search.getUserX())) {
         throw new CustomException(ErrorCode.USER_LOCATION_NOT_PROVIDED);
       }
-
-      restaurants = restaurantRepository.getRestaurantByRegionAndPlaceNameAndCategoryNameOrderByDistance(
-          search.getUserY(),
-          search.getUserX(),
-          search.getRegion().toString(),
-          search.getPlaceName(),
-          categoryName,
-          pageable);
-    } else {
-      restaurants = restaurantRepository.getRestaurantByRegionAndCategoryNameAndPlaceName(
-          search.getRegion().toString(),
-          search.getPlaceName(),
-          categoryName,
-          pageable);
     }
 
-    return restaurants;
+    // 정렬 기준에 따라 쿼리 메소드 실행
+    return restaurantRepository.findRestaurantsByFilters(search, pageable);
   }
 
   public RestaurantResponse getRestaurant(Long restaurantId) {
@@ -109,7 +87,7 @@ public class RestaurantService {
     // Pageable 객체 생성 (페이지, 사이즈, 정렬 방식)
     Pageable pageable = PageRequest.of(page, size);
 
-    return restaurantReviewRepository.getRestaurantReviewByRestaurantId(restaurantId, pageable);
+    return restaurantReviewRepository.findRestaurantReviewsByRestaurantId(restaurantId, pageable);
   }
 
   @Transactional


### PR DESCRIPTION
### Pull Request
> ### 변경사항
> 📌 **AS-IS**
- 식당 조회 및 리뷰 조회 nativequery 사용

> 🔖 **TO-BE**
- `QueryDsl` 라이브러리 의존성 추가 (`querydsl-jpa` 및 `querydsl-apt`)
- `JPAQueryFactory`를 빈으로 등록하여 QueryDsl을 사용할 수 있도록 설정
- `EntityManager`를 통해 `JPAQueryFactory`를 구성하여 동적 쿼리 작성 환경 설정
- 기존의 JPA 네이티브 쿼리를 `QueryDSL`로 변경하여 레스토랑 조회 로직을 리팩토링
- `RestaurantRepositoryCustom`, `RestaurantRepositoryCustomImpl`, `RestaurantReviewRepositoryCustom` 및 `RestaurantReviewRepositoryCustomImpl`을 추가하여 `QueryDSL`을 활용한 동적 쿼리 작성