### PR TITLE
chore(config): 허용 헤더값 제한

### DIFF
--- a/src/main/java/com/zb/meeteat/config/CorsConfig.java
+++ b/src/main/java/com/zb/meeteat/config/CorsConfig.java
@@ -22,8 +22,8 @@ public class CorsConfig {
     // 모든 HTTP 메서드 허용 (GET, POST, PUT, DELETE 등)
     config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH" ));
 
-    // 헤더 허용
-    config.setAllowedHeaders(List.of("*"));
+    // 허용할 헤더를 특정 값으로 제한
+    config.setAllowedHeaders(List.of("Authorization", "Content-Type"));
 
     // 자격 증명 허용 (Authorization 헤더 포함)
     config.setAllowCredentials(true);


### PR DESCRIPTION
### **Pull Request**  

> ### **변경사항**  
>  
> 📌 **AS-IS**  
> - CORS 정책에서 모든 헤더(`*`)를 허용하도록 설정됨  
>  
> 🔖 **TO-BE**  
> - CORS 정책을 수정하여 `Authorization`, `Content-Type` 헤더만 허용  
> - 기존: `setAllowedHeaders(List.of("*"))`  
> - 변경: `setAllowedHeaders(List.of("Authorization", "Content-Type"))`  