### PR TITLE
refactor: 평균 평점을 소수점 한 자리로 반올림

### DIFF
--- a/src/main/java/com/zb/meeteat/domain/restaurant/dto/RestaurantResponse.java
+++ b/src/main/java/com/zb/meeteat/domain/restaurant/dto/RestaurantResponse.java
@@ -36,8 +36,11 @@ public class RestaurantResponse {
     res.setY(restaurant.getY());
     res.setRoad_address_name(restaurant.getRoadAddressName());
     res.setCategory_name(restaurant.getCategoryName());
+
     double rating = restaurant.getRating() == null ? 0 : restaurant.getRating();
+    rating = Math.round(rating * 10.0) / 10.0;
     res.setRating(rating);
+
     res.setThumbnail(thumbnail);
     return res;
   }

--- a/src/main/java/com/zb/meeteat/domain/restaurant/service/RestaurantService.java
+++ b/src/main/java/com/zb/meeteat/domain/restaurant/service/RestaurantService.java
@@ -173,7 +173,7 @@ public class RestaurantService {
         .id(myReview.getId())
         .rating(myReview.getRating())
         .description(myReview.getDescription())
-        .imageUrl(myReview.getImgUrl())
+        .imgUrl(myReview.getImgUrl())
         .nickName(myReview.getUser().getNickname())
         .createdAt(myReview.getCreatedAt())
         .build();
@@ -197,10 +197,13 @@ public class RestaurantService {
 
   private void updateRestaurantRating(Restaurant restaurant) {
     List<RestaurantReview> reviews = restaurantReviewRepository.findAllByRestaurant(restaurant);
-    Double avgRating = reviews.stream()
+    double avgRating = reviews.stream()
         .mapToInt(RestaurantReview::getRating)
         .average()
         .orElse(0.0);
+
+    // 소수점 한 자리까지 반올림
+    avgRating = Math.round(avgRating * 10.0) / 10.0;
 
     restaurant.setRating(avgRating);
     restaurantRepository.save(restaurant);


### PR DESCRIPTION
### Pull Request
> ### 변경사항
> 📌 **AS-IS**
- 식당 평점 =  총평점 / 총 리뷰 개수로 계산

> 🔖 **TO-BE**
- 식당 평점은 소수점 한 자리까지 반올림하여 저장되도록 수정되었습니다.
  - 기존에 저장된 평점을 유지하기 위해, 식당 리스트 출력 시 평점이 소수점 한 자리로 반올림되도록 수정하였습니다.